### PR TITLE
Update README.md to direct to new docs vs. old Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ Golang code for the `bloodhound-cli` binary in [BloodHound](https://github.com/S
 
 ## Usage
 
-Execute `./bloodhound-cli help` for usage information (see below). More information about BloodHound and how to manage it with `bloodhound-cli` can be found on the [BloodHound Wiki](https://github.com/SpecterOps/BloodHound/wiki/).
-
-## Usage
-
 Execute `./bloodhound-cli help` for usage information (see below). 
 
 More information about BloodHound and how to manage it with `bloodhound-cli` can be found on the [[BloodHound Community Edition Quickstart Guide](https://github.com/SpecterOps/BloodHound/wiki/](https://bloodhound.specterops.io/get-started/quickstart/community-edition-quickstart)), which is part of the [BloodHound documentation](https://bloodhound.specterops.io/home).

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Golang code for the `bloodhound-cli` binary in [BloodHound](https://github.com/S
 
 Execute `./bloodhound-cli help` for usage information (see below). More information about BloodHound and how to manage it with `bloodhound-cli` can be found on the [BloodHound Wiki](https://github.com/SpecterOps/BloodHound/wiki/).
 
+## Usage
+
+Execute `./bloodhound-cli help` for usage information (see below). 
+
+More information about BloodHound and how to manage it with `bloodhound-cli` can be found on the [[BloodHound Community Edition Quickstart Guide](https://github.com/SpecterOps/BloodHound/wiki/](https://bloodhound.specterops.io/get-started/quickstart/community-edition-quickstart)), which is part of the [BloodHound documentation](https://bloodhound.specterops.io/home).
+
 ## Compilation
 
 Releases are compiled with the following command to set version and build date information:


### PR DESCRIPTION
Old Readme pointed to the Wiki for more info on using bloodhound-cli but the Wiki doesn't even mention bloodhound-cli.