### PR TITLE
Update readme.md to reflect new documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ Golang code for the `bloodhound-cli` binary in [BloodHound](https://github.com/S
 
 ## Usage
 
-Execute `./bloodhound-cli help` for usage information (see below). More information about BloodHound and how to manage it with `bloodhound-cli` can be found on the [BloodHound Wiki](https://github.com/SpecterOps/BloodHound/wiki/).
-
-## Usage
-
 Execute `./bloodhound-cli help` for usage information (see below). 
 
 More information about BloodHound and how to manage it with `bloodhound-cli` can be found on the [[BloodHound Community Edition Quickstart Guide](https://github.com/SpecterOps/BloodHound/wiki/](https://bloodhound.specterops.io/get-started/quickstart/community-edition-quickstart)), which is part of the [BloodHound documentation](https://bloodhound.specterops.io/home).


### PR DESCRIPTION
Old Readme pointed to Wiki for more info on bloodhound-cli but wiki didn't discuss the topic. Changed links over to new documentation. 