### PR TITLE
Feature: Home Directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Added support for a dedicated config directory to act as the configuration home for the JSON configuration file and Docker YAML files
-  * Added a `config_directory` value to the JSON configuration file to control the config directory path
-  * The default value is the user's XDG config home directory and `bloodhound`
-    * i.e., the equivalent of `~/.config/bloodhound` on Unix, \
-      `~/Library/Application Support/bloodhound` on macOS, and \
-      `%LOCALAPPDATA%\bloodhound` on Windows
-    * We use a lowercase `bloodhound` to match the directory used by older installations of BloodHound, so we add to that directory if it exists
-  * You can place BloodHound CLI anywhere and run it from any location, and it will always look in the config directory for the JSON and YAML files
-  * The CLI creates the directory with a `0777` permissions mask so it is accessible to all BloodHound users in multi-user environments
-  * The permissions follow your [umask](https://man7.org/linux/man-pages/man2/umask.2.html), so the typical user mask of `0022` will set the permissions to `0755`
+* Added support for a dedicated config directory to act as the configuration home for the JSON configuration file and default Docker YAML files
+  * The directory is the user's XDG config home directory and `bloodhound`
+      * i.e., the equivalent of `~/.config/bloodhound` on Unix, \
+        `~/Library/Application Support/bloodhound` on macOS, and \
+        `%LOCALAPPDATA%\bloodhound` on Windows
+      * We use a lowercase `bloodhound` to match the directory used by older installations of BloodHound
+    * You can place BloodHound CLI anywhere and run it from any location, and it will always look in the config directory for the JSON and default YAML files
+    * The CLI creates the directory with a `0777` permissions mask so it is accessible to all BloodHound users in multi-user environments
+    * The permissions follow your [umask](https://man7.org/linux/man-pages/man2/umask.2.html), so the typical user mask of `0022` will set the permissions to `0755`
+* Added a `config_directory` value to the JSON configuration file to control the config directory path
+  * Changing this path will change where BloodHound CLI looks for the Docker YAML files
+  * BloodHound CLI will continue to look in the default location for the JSON config file 
 * Added checks that ensure the configured directory will work as expected every time BloodHound CLI runs
   * The first check ensures the directory exists and creates the directory if it does not
   * The second check ensures the config directory has proper permissions that will allow BloodHound CLI to read and write
+* Added a `-f` or `--file` flag to override the location of the YAML file to use for Docker
+  * Providing a file path will override where BloodHound CLI looks for the YAML file
+  * e.g., `./bloodhound-cli -f /Users/Mable/BloodHound/custom-docker-compose.yml containers up`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2025-7-1
+
+### Added
+
+* Added support for a dedicated home directory to act as the home for the JSON configuration file and Docker YAML files
+  * Added a `home_directory` value to the JSON configuration file to control the home directory path
+  * The default value is the user's home directory and `.BloodHound` (i.e., the equivalent of `~/.BloodHound`)
+  * You can place and run BloodHound CLI from any location, and it will always look in the home directory for the JSON and YAML files
+* Added checks that ensure the configured home directory will work as expected every time BloodHound CLI is run
+  * The first check ensures the directory exists and creates the directory if it does not
+  * The second check ensures the home directory has proper permissions that will allow BloodHound CLI to read and write (e.g., `0600`)
+    * Permissions may exceed `0600`, but must at least allow read and write for the current user
+
+### Changed
+
+* Every command that runs a Docker command will now ensure the required YAML file exists before proceeding
+
 ## [0.1.6] - 2025-4-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.7] - 2025-7-1
+## [0.1.7] - 2025-7-2
 
 ### Added
 
 * Added support for a dedicated home directory to act as the home for the JSON configuration file and Docker YAML files
   * Added a `home_directory` value to the JSON configuration file to control the home directory path
-  * The default value is the user's home directory and `.BloodHound` (i.e., the equivalent of `~/.BloodHound`)
-  * You can place and run BloodHound CLI from any location, and it will always look in the home directory for the JSON and YAML files
-* Added checks that ensure the configured home directory will work as expected every time BloodHound CLI is run
+  * The default value is the user's XDG data home directory and `.BloodHound`
+    * i.e., the equivalent of `~/.local/share` on Unix, `~/Library/Application Support` on macOS, and  `%LOCALAPPDATA%` on Windows
+  * You can place BloodHound CLI anywhere and run it from any location, and it will always look in the home directory for the JSON and YAML files
+  * The CLI creates the directory with a `0777` permissions mask so it is accessible to all BloodHound users
+  * Users may reduce permissions or set a custom umask if sharing directory access will not be required for an installation
+* Added checks that ensure the configured home directory will work as expected every time BloodHound CLI runs
   * The first check ensures the directory exists and creates the directory if it does not
-  * The second check ensures the home directory has proper permissions that will allow BloodHound CLI to read and write (e.g., `0600`)
-    * Permissions may exceed `0600`, but must at least allow read and write for the current user
+  * The second check ensures the home directory has proper permissions that will allow BloodHound CLI to read and write (e.g., >= `0600`)
+    * Permissions may exceed `0600`, but must at least allow the current user to read and write
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added support for a dedicated config directory to act as the configuration home for the JSON configuration file and default Docker YAML files
   * The directory is the user's XDG config home directory and `bloodhound`
-      * i.e., the equivalent of `~/.config/bloodhound` on Unix, \
-        `~/Library/Application Support/bloodhound` on macOS, and \
-        `%LOCALAPPDATA%\bloodhound` on Windows
-      * We use a lowercase `bloodhound` to match the directory used by older installations of BloodHound
-    * You can place BloodHound CLI anywhere and run it from any location, and it will always look in the config directory for the JSON and default YAML files
-    * The CLI creates the directory with a `0777` permissions mask so it is accessible to all BloodHound users in multi-user environments
-    * The permissions follow your [umask](https://man7.org/linux/man-pages/man2/umask.2.html), so the typical user mask of `0022` will set the permissions to `0755`
+    * i.e., the equivalent of `~/.config/bloodhound` on Unix, \
+      `~/Library/Application Support/bloodhound` on macOS, and \
+      `%LOCALAPPDATA%\bloodhound` on Windows
+    * We use a lowercase `bloodhound` to match the directory used by older installations of BloodHound
+  * You can place BloodHound CLI anywhere and run it from any location, and it will always look in the config directory for the JSON and default YAML files
+  * The CLI creates the directory with a `0777` permissions mask so it is accessible to all BloodHound users in multi-user environments
+  * The permissions follow your [umask](https://man7.org/linux/man-pages/man2/umask.2.html), so the typical user mask of `0022` will set the permissions to `0755`
 * Added a `config_directory` value to the JSON configuration file to control the config directory path
   * Changing this path will change where BloodHound CLI looks for the Docker YAML files
   * BloodHound CLI will continue to look in the default location for the JSON config file 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Added support for a dedicated home directory to act as the home for the JSON configuration file and Docker YAML files
-  * Added a `data_directory` value to the JSON configuration file to control the home directory path
+* Added support for a dedicated config directory to act as the configuration home for the JSON configuration file and Docker YAML files
+  * Added a `config_directory` value to the JSON configuration file to control the config directory path
   * The default value is the user's XDG config home directory and `bloodhound`
     * i.e., the equivalent of `~/.config` on Unix, `~/Library/Application Support` on macOS, and  `%LOCALAPPDATA%` on Windows
       * i.e., the equivalent of `~/.config/BloodHound` on Unix, \
         `~/Library/Application Support/BloodHound` on macOS, and \
         `%LOCALAPPDATA%\BloodHound` on Windows
     * We use a lowercase `bloodhound` to match the directory used by older installations of BloodHound, so we add to that directory if it exists
-  * You can place BloodHound CLI anywhere and run it from any location, and it will always look in the home directory for the JSON and YAML files
+  * You can place BloodHound CLI anywhere and run it from any location, and it will always look in the config directory for the JSON and YAML files
   * The CLI creates the directory with a `0777` permissions mask so it is accessible to all BloodHound users in multi-user environments
   * The permissions follow your [umask](https://man7.org/linux/man-pages/man2/umask.2.html), so a umask of `0022` will set the permissions to `0755`
-* Added checks that ensure the configured home directory will work as expected every time BloodHound CLI runs
+* Added checks that ensure the configured directory will work as expected every time BloodHound CLI runs
   * The first check ensures the directory exists and creates the directory if it does not
-  * The second check ensures the home directory has proper permissions that will allow BloodHound CLI to read and write
+  * The second check ensures the config directory has proper permissions that will allow BloodHound CLI to read and write
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     * We use a lowercase `bloodhound` to match the directory used by older installations of BloodHound, so we add to that directory if it exists
   * You can place BloodHound CLI anywhere and run it from any location, and it will always look in the config directory for the JSON and YAML files
   * The CLI creates the directory with a `0777` permissions mask so it is accessible to all BloodHound users in multi-user environments
-  * The permissions follow your [umask](https://man7.org/linux/man-pages/man2/umask.2.html), so a user mask of `0022` will set the permissions to `0755`
+  * The permissions follow your [umask](https://man7.org/linux/man-pages/man2/umask.2.html), so the typical user mask of `0022` will set the permissions to `0755`
 * Added checks that ensure the configured directory will work as expected every time BloodHound CLI runs
   * The first check ensures the directory exists and creates the directory if it does not
   * The second check ensures the config directory has proper permissions that will allow BloodHound CLI to read and write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.7] - 2025-7-7
+## [0.1.7] - 2025-7-9
 
 ### Added
 
 * Added support for a dedicated config directory to act as the configuration home for the JSON configuration file and Docker YAML files
   * Added a `config_directory` value to the JSON configuration file to control the config directory path
   * The default value is the user's XDG config home directory and `bloodhound`
-    * i.e., the equivalent of `~/.config` on Unix, `~/Library/Application Support` on macOS, and  `%LOCALAPPDATA%` on Windows
-      * i.e., the equivalent of `~/.config/bloodhound` on Unix, \
-        `~/Library/Application Support/bloodhound` on macOS, and \
-        `%LOCALAPPDATA%\bloodhound` on Windows
+    * i.e., the equivalent of `~/.config/bloodhound` on Unix, \
+      `~/Library/Application Support/bloodhound` on macOS, and \
+      `%LOCALAPPDATA%\bloodhound` on Windows
     * We use a lowercase `bloodhound` to match the directory used by older installations of BloodHound, so we add to that directory if it exists
   * You can place BloodHound CLI anywhere and run it from any location, and it will always look in the config directory for the JSON and YAML files
   * The CLI creates the directory with a `0777` permissions mask so it is accessible to all BloodHound users in multi-user environments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.7] - 2025-7-2
+## [0.1.7] - 2025-7-7
 
 ### Added
 
@@ -12,9 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Added a `data_directory` value to the JSON configuration file to control the home directory path
   * The default value is the user's XDG config home directory and `bloodhound`
     * i.e., the equivalent of `~/.config` on Unix, `~/Library/Application Support` on macOS, and  `%LOCALAPPDATA%` on Windows
+      * i.e., the equivalent of `~/.config/BloodHound` on Unix, \
+        `~/Library/Application Support/BloodHound` on macOS, and \
+        `%LOCALAPPDATA%\BloodHound` on Windows
     * We use a lowercase `bloodhound` to match the directory used by older installations of BloodHound, so we add to that directory if it exists
   * You can place BloodHound CLI anywhere and run it from any location, and it will always look in the home directory for the JSON and YAML files
-  * The CLI creates the directory with a `0777` permissions mask so it is accessible to all BloodHound users
+  * The CLI creates the directory with a `0777` permissions mask so it is accessible to all BloodHound users in multi-user environments
   * The permissions follow your [umask](https://man7.org/linux/man-pages/man2/umask.2.html), so a umask of `0022` will set the permissions to `0755`
 * Added checks that ensure the configured home directory will work as expected every time BloodHound CLI runs
   * The first check ensures the directory exists and creates the directory if it does not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Added a `config_directory` value to the JSON configuration file to control the config directory path
   * The default value is the user's XDG config home directory and `bloodhound`
     * i.e., the equivalent of `~/.config` on Unix, `~/Library/Application Support` on macOS, and  `%LOCALAPPDATA%` on Windows
-      * i.e., the equivalent of `~/.config/BloodHound` on Unix, \
-        `~/Library/Application Support/BloodHound` on macOS, and \
-        `%LOCALAPPDATA%\BloodHound` on Windows
+      * i.e., the equivalent of `~/.config/bloodhound` on Unix, \
+        `~/Library/Application Support/bloodhound` on macOS, and \
+        `%LOCALAPPDATA%\bloodhound` on Windows
     * We use a lowercase `bloodhound` to match the directory used by older installations of BloodHound, so we add to that directory if it exists
   * You can place BloodHound CLI anywhere and run it from any location, and it will always look in the config directory for the JSON and YAML files
   * The CLI creates the directory with a `0777` permissions mask so it is accessible to all BloodHound users in multi-user environments
-  * The permissions follow your [umask](https://man7.org/linux/man-pages/man2/umask.2.html), so a umask of `0022` will set the permissions to `0755`
+  * The permissions follow your [umask](https://man7.org/linux/man-pages/man2/umask.2.html), so a user mask of `0022` will set the permissions to `0755`
 * Added checks that ensure the configured directory will work as expected every time BloodHound CLI runs
   * The first check ensures the directory exists and creates the directory if it does not
   * The second check ensures the config directory has proper permissions that will allow BloodHound CLI to read and write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added support for a dedicated home directory to act as the home for the JSON configuration file and Docker YAML files
   * Added a `home_directory` value to the JSON configuration file to control the home directory path
-  * The default value is the user's XDG data home directory and `.BloodHound`
-    * i.e., the equivalent of `~/.local/share` on Unix, `~/Library/Application Support` on macOS, and  `%LOCALAPPDATA%` on Windows
+  * The default value is the user's XDG config home directory and `BloodHound`
+    * i.e., the equivalent of `~/.config` on Unix, `~/Library/Application Support` on macOS, and  `%LOCALAPPDATA%` on Windows
   * You can place BloodHound CLI anywhere and run it from any location, and it will always look in the home directory for the JSON and YAML files
   * The CLI creates the directory with a `0777` permissions mask so it is accessible to all BloodHound users
   * Users may reduce permissions or set a custom umask if sharing directory access will not be required for an installation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added support for a dedicated home directory to act as the home for the JSON configuration file and Docker YAML files
-  * Added a `home_directory` value to the JSON configuration file to control the home directory path
-  * The default value is the user's XDG config home directory and `BloodHound`
+  * Added a `data_directory` value to the JSON configuration file to control the home directory path
+  * The default value is the user's XDG config home directory and `bloodhound`
     * i.e., the equivalent of `~/.config` on Unix, `~/Library/Application Support` on macOS, and  `%LOCALAPPDATA%` on Windows
+    * We use a lowercase `bloodhound` to match the directory used by older installations of BloodHound, so we add to that directory if it exists
   * You can place BloodHound CLI anywhere and run it from any location, and it will always look in the home directory for the JSON and YAML files
   * The CLI creates the directory with a `0777` permissions mask so it is accessible to all BloodHound users
   * The permissions follow your [umask](https://man7.org/linux/man-pages/man2/umask.2.html), so a umask of `0022` will set the permissions to `0755`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     * i.e., the equivalent of `~/.config` on Unix, `~/Library/Application Support` on macOS, and  `%LOCALAPPDATA%` on Windows
   * You can place BloodHound CLI anywhere and run it from any location, and it will always look in the home directory for the JSON and YAML files
   * The CLI creates the directory with a `0777` permissions mask so it is accessible to all BloodHound users
-  * Users may reduce permissions or set a custom umask if sharing directory access will not be required for an installation
+  * The permissions follow your [umask](https://man7.org/linux/man-pages/man2/umask.2.html), so a umask of `0022` will set the permissions to `0755`
 * Added checks that ensure the configured home directory will work as expected every time BloodHound CLI runs
   * The first check ensures the directory exists and creates the directory if it does not
-  * The second check ensures the home directory has proper permissions that will allow BloodHound CLI to read and write (e.g., >= `0600`)
-    * Permissions may exceed `0600`, but must at least allow the current user to read and write
+  * The second check ensures the home directory has proper permissions that will allow BloodHound CLI to read and write
 
 ### Changed
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -23,7 +23,7 @@ func init() {
 }
 
 func evaluateBloodHound(cmd *cobra.Command, args []string) {
-	err := docker.EvaluateDockerComposeStatus(true)
+	err := docker.EvaluateDockerComposeStatus()
 	if err != nil {
 		return
 	}

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -23,10 +23,7 @@ func init() {
 }
 
 func evaluateBloodHound(cmd *cobra.Command, args []string) {
-	err := docker.EvaluateDockerComposeStatus()
-	if err != nil {
-		return
-	}
+	docker.EvaluateDockerComposeStatus()
 	docker.EvaluateEnvironment()
 	fmt.Println("[+] Environment checks are complete!")
 }

--- a/cmd/containersBuild.go
+++ b/cmd/containersBuild.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	docker "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
-	"path/filepath"
 )
 
 // containersBuildCmd represents the build command
@@ -25,5 +24,5 @@ func init() {
 func buildContainers(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Starting build")
-	docker.RunDockerComposeUpgrade(filepath.Join(docker.GetBloodHoundDir(), "docker-compose.yml"))
+	docker.RunDockerComposeUpgrade(docker.GetYamlFilePath())
 }

--- a/cmd/containersBuild.go
+++ b/cmd/containersBuild.go
@@ -26,5 +26,5 @@ func init() {
 func buildContainers(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Starting build")
-	docker.RunDockerComposeUpgrade(docker.GetYamlFilePath(dirOverride))
+	docker.RunDockerComposeUpgrade(docker.GetYamlFilePath(fileOverride))
 }

--- a/cmd/containersBuild.go
+++ b/cmd/containersBuild.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	docker "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
+	"path/filepath"
 )
 
 // containersBuildCmd represents the build command
@@ -24,5 +25,5 @@ func init() {
 func buildContainers(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Starting build")
-	docker.RunDockerComposeUpgrade("docker-compose.yml")
+	docker.RunDockerComposeUpgrade(filepath.Join(docker.GetBloodHoundDir(), "docker-compose.yml"))
 }

--- a/cmd/containersBuild.go
+++ b/cmd/containersBuild.go
@@ -26,5 +26,5 @@ func init() {
 func buildContainers(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Starting build")
-	docker.RunDockerComposeUpgrade(docker.GetYamlFilePath())
+	docker.RunDockerComposeUpgrade(docker.GetYamlFilePath(dirOverride))
 }

--- a/cmd/containersDown.go
+++ b/cmd/containersDown.go
@@ -27,5 +27,5 @@ func init() {
 func containersDown(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Bringing down the BloodHound environment")
-	docker.RunDockerComposeDown(docker.GetYamlFilePath(dirOverride), volumes)
+	docker.RunDockerComposeDown(docker.GetYamlFilePath(fileOverride), volumes)
 }

--- a/cmd/containersDown.go
+++ b/cmd/containersDown.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	docker "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
-	"path/filepath"
 )
 
 var volumes bool
@@ -27,5 +26,5 @@ func init() {
 func containersDown(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Bringing down the BloodHound environment")
-	docker.RunDockerComposeDown(filepath.Join(docker.GetBloodHoundDir(), "docker-compose.yml"), volumes)
+	docker.RunDockerComposeDown(docker.GetYamlFilePath(), volumes)
 }

--- a/cmd/containersDown.go
+++ b/cmd/containersDown.go
@@ -27,5 +27,5 @@ func init() {
 func containersDown(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Bringing down the BloodHound environment")
-	docker.RunDockerComposeDown(docker.GetYamlFilePath(), volumes)
+	docker.RunDockerComposeDown(docker.GetYamlFilePath(dirOverride), volumes)
 }

--- a/cmd/containersDown.go
+++ b/cmd/containersDown.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	docker "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
+	"path/filepath"
 )
 
 var volumes bool
@@ -26,5 +27,5 @@ func init() {
 func containersDown(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Bringing down the BloodHound environment")
-	docker.RunDockerComposeDown("docker-compose.yml", volumes)
+	docker.RunDockerComposeDown(filepath.Join(docker.GetBloodHoundDir(), "docker-compose.yml"), volumes)
 }

--- a/cmd/containersRestart.go
+++ b/cmd/containersRestart.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	docker "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
+	"path/filepath"
 )
 
 // containersRestartCmd represents the restart command
@@ -22,5 +23,5 @@ func init() {
 func containersRestart(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Restarting the BloodHound environment")
-	docker.RunDockerComposeRestart("docker-compose.yml")
+	docker.RunDockerComposeRestart(filepath.Join(docker.GetBloodHoundDir(), "docker-compose.yml"))
 }

--- a/cmd/containersRestart.go
+++ b/cmd/containersRestart.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	docker "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
-	"path/filepath"
 )
 
 // containersRestartCmd represents the restart command
@@ -23,5 +22,5 @@ func init() {
 func containersRestart(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Restarting the BloodHound environment")
-	docker.RunDockerComposeRestart(filepath.Join(docker.GetBloodHoundDir(), "docker-compose.yml"))
+	docker.RunDockerComposeRestart(docker.GetYamlFilePath())
 }

--- a/cmd/containersRestart.go
+++ b/cmd/containersRestart.go
@@ -23,5 +23,5 @@ func init() {
 func containersRestart(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Restarting the BloodHound environment")
-	docker.RunDockerComposeRestart(docker.GetYamlFilePath())
+	docker.RunDockerComposeRestart(docker.GetYamlFilePath(dirOverride))
 }

--- a/cmd/containersRestart.go
+++ b/cmd/containersRestart.go
@@ -23,5 +23,5 @@ func init() {
 func containersRestart(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Restarting the BloodHound environment")
-	docker.RunDockerComposeRestart(docker.GetYamlFilePath(dirOverride))
+	docker.RunDockerComposeRestart(docker.GetYamlFilePath(fileOverride))
 }

--- a/cmd/containersStart.go
+++ b/cmd/containersStart.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	docker "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
+	"path/filepath"
 )
 
 // containersStartCmd represents the start command
@@ -22,5 +23,5 @@ func init() {
 func containersStart(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Starting the BloodHound environment")
-	docker.RunDockerComposeStart("docker-compose.yml")
+	docker.RunDockerComposeStart(filepath.Join(docker.GetBloodHoundDir(), "docker-compose.yml"))
 }

--- a/cmd/containersStart.go
+++ b/cmd/containersStart.go
@@ -23,5 +23,5 @@ func init() {
 func containersStart(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Starting the BloodHound environment")
-	docker.RunDockerComposeStart(docker.GetYamlFilePath())
+	docker.RunDockerComposeStart(docker.GetYamlFilePath(dirOverride))
 }

--- a/cmd/containersStart.go
+++ b/cmd/containersStart.go
@@ -23,5 +23,5 @@ func init() {
 func containersStart(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Starting the BloodHound environment")
-	docker.RunDockerComposeStart(docker.GetYamlFilePath(dirOverride))
+	docker.RunDockerComposeStart(docker.GetYamlFilePath(fileOverride))
 }

--- a/cmd/containersStart.go
+++ b/cmd/containersStart.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	docker "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
-	"path/filepath"
 )
 
 // containersStartCmd represents the start command
@@ -23,5 +22,5 @@ func init() {
 func containersStart(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Starting the BloodHound environment")
-	docker.RunDockerComposeStart(filepath.Join(docker.GetBloodHoundDir(), "docker-compose.yml"))
+	docker.RunDockerComposeStart(docker.GetYamlFilePath())
 }

--- a/cmd/containersStop.go
+++ b/cmd/containersStop.go
@@ -23,5 +23,5 @@ func init() {
 func containersStop(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Stopping the BloodHound environment")
-	docker.RunDockerComposeStop(docker.GetYamlFilePath())
+	docker.RunDockerComposeStop(docker.GetYamlFilePath(dirOverride))
 }

--- a/cmd/containersStop.go
+++ b/cmd/containersStop.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	docker "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
-	"path/filepath"
 )
 
 // containersStopCmd represents the stop command
@@ -23,5 +22,5 @@ func init() {
 func containersStop(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Stopping the BloodHound environment")
-	docker.RunDockerComposeStop(filepath.Join(docker.GetBloodHoundDir(), "docker-compose.yml"))
+	docker.RunDockerComposeStop(docker.GetYamlFilePath())
 }

--- a/cmd/containersStop.go
+++ b/cmd/containersStop.go
@@ -23,5 +23,5 @@ func init() {
 func containersStop(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Stopping the BloodHound environment")
-	docker.RunDockerComposeStop(docker.GetYamlFilePath(dirOverride))
+	docker.RunDockerComposeStop(docker.GetYamlFilePath(fileOverride))
 }

--- a/cmd/containersStop.go
+++ b/cmd/containersStop.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	docker "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
+	"path/filepath"
 )
 
 // containersStopCmd represents the stop command
@@ -22,5 +23,5 @@ func init() {
 func containersStop(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Stopping the BloodHound environment")
-	docker.RunDockerComposeStop("docker-compose.yml")
+	docker.RunDockerComposeStop(filepath.Join(docker.GetBloodHoundDir(), "docker-compose.yml"))
 }

--- a/cmd/containersUp.go
+++ b/cmd/containersUp.go
@@ -23,5 +23,5 @@ func init() {
 func containersUp(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Bringing up the BloodHound environment")
-	docker.RunDockerComposeUp(docker.GetYamlFilePath())
+	docker.RunDockerComposeUp(docker.GetYamlFilePath(dirOverride))
 }

--- a/cmd/containersUp.go
+++ b/cmd/containersUp.go
@@ -23,5 +23,5 @@ func init() {
 func containersUp(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Bringing up the BloodHound environment")
-	docker.RunDockerComposeUp(docker.GetYamlFilePath(dirOverride))
+	docker.RunDockerComposeUp(docker.GetYamlFilePath(fileOverride))
 }

--- a/cmd/containersUp.go
+++ b/cmd/containersUp.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	docker "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
+	"path/filepath"
 )
 
 // containersUpCmd represents the up command
@@ -22,5 +23,5 @@ func init() {
 func containersUp(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Bringing up the BloodHound environment")
-	docker.RunDockerComposeUp("docker-compose.yml")
+	docker.RunDockerComposeUp(filepath.Join(docker.GetBloodHoundDir(), "docker-compose.yml"))
 }

--- a/cmd/containersUp.go
+++ b/cmd/containersUp.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	docker "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
-	"path/filepath"
 )
 
 // containersUpCmd represents the up command
@@ -23,5 +22,5 @@ func init() {
 func containersUp(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Bringing up the BloodHound environment")
-	docker.RunDockerComposeUp(filepath.Join(docker.GetBloodHoundDir(), "docker-compose.yml"))
+	docker.RunDockerComposeUp(docker.GetYamlFilePath())
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -37,5 +37,5 @@ func installBloodHound(cmd *cobra.Command, args []string) {
 		log.Fatalf("Error creating config directory: %v", configErr)
 	}
 	fmt.Println("[+] Starting BloodHound environment installation")
-	docker.RunDockerComposeInstall(docker.GetYamlFilePath(dirOverride))
+	docker.RunDockerComposeInstall(docker.GetYamlFilePath(fileOverride))
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -5,7 +5,6 @@ import (
 	docker "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
 	"log"
-	"path/filepath"
 )
 
 // installCmd represents the install command
@@ -39,5 +38,5 @@ func installBloodHound(cmd *cobra.Command, args []string) {
 		log.Fatalf("Error creating home directory: %v", homeErr)
 	}
 	fmt.Println("[+] Starting BloodHound environment installation")
-	docker.RunDockerComposeInstall(filepath.Join(docker.GetBloodHoundDir(), "docker-compose.yml"))
+	docker.RunDockerComposeInstall(docker.GetYamlFilePath())
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -37,5 +37,5 @@ func installBloodHound(cmd *cobra.Command, args []string) {
 		log.Fatalf("Error creating config directory: %v", configErr)
 	}
 	fmt.Println("[+] Starting BloodHound environment installation")
-	docker.RunDockerComposeInstall(docker.GetYamlFilePath())
+	docker.RunDockerComposeInstall(docker.GetYamlFilePath(dirOverride))
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -32,7 +32,7 @@ func init() {
 // installBloodHound sets up the BloodHound environment by verifying Docker Compose status, creating the required home directory, and launching the Docker containers using the installation configuration.
 func installBloodHound(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
-	homeErr := docker.MakeHomeDir()
+	homeErr := docker.MakeDataDir()
 	if homeErr != nil {
 		log.Fatalf("Error creating home directory: %v", homeErr)
 	}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -32,9 +32,9 @@ func init() {
 // installBloodHound sets up the BloodHound environment by verifying Docker Compose status, creating the required home directory, and launching the Docker containers using the installation configuration.
 func installBloodHound(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
-	homeErr := docker.MakeDataDir()
-	if homeErr != nil {
-		log.Fatalf("Error creating home directory: %v", homeErr)
+	configErr := docker.MakeConfigDir()
+	if configErr != nil {
+		log.Fatalf("Error creating config directory: %v", configErr)
 	}
 	fmt.Println("[+] Starting BloodHound environment installation")
 	docker.RunDockerComposeInstall(docker.GetYamlFilePath())

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -29,10 +29,7 @@ func init() {
 }
 
 func installBloodHound(cmd *cobra.Command, args []string) {
-	err := docker.EvaluateDockerComposeStatus()
-	if err != nil {
-		return
-	}
+	docker.EvaluateDockerComposeStatus()
 	homeErr := docker.MakeHomeDir()
 	if homeErr != nil {
 		log.Fatalf("Error creating home directory: %v", homeErr)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	docker "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
+	"log"
+	"path/filepath"
 )
 
 // installCmd represents the install command
@@ -28,10 +30,14 @@ func init() {
 }
 
 func installBloodHound(cmd *cobra.Command, args []string) {
-	err := docker.EvaluateDockerComposeStatus(true)
+	err := docker.EvaluateDockerComposeStatus()
 	if err != nil {
 		return
 	}
+	homeErr := docker.MakeHomeDir()
+	if homeErr != nil {
+		log.Fatalf("Error creating home directory: %v", homeErr)
+	}
 	fmt.Println("[+] Starting BloodHound environment installation")
-	docker.RunDockerComposeInstall("docker-compose.yml")
+	docker.RunDockerComposeInstall(filepath.Join(docker.GetBloodHoundDir(), "docker-compose.yml"))
 }

--- a/cmd/internal/docker.go
+++ b/cmd/internal/docker.go
@@ -176,9 +176,11 @@ func RunDockerComposeUninstall(yaml string) {
 		os.Exit(0)
 	}
 
-	delErr := DeleteHomeDir(homeDir)
+	delErr := DeleteDir(homeDir)
 	if delErr != nil {
 		log.Fatalf("Error trying to delete the home directory: %v\n", delErr)
+	} else {
+		fmt.Println("[+] Successfully delete the BloodHound home directory!")
 	}
 	fmt.Println("[+] Uninstall was successful. You can re-install with `./bloodhound-cli install`.")
 	fmt.Println("[+] The home directory and config will be recreated if you continue using BloodHound CLI.")

--- a/cmd/internal/docker.go
+++ b/cmd/internal/docker.go
@@ -59,7 +59,7 @@ func (c Containers) Swap(i, j int) {
 
 // EvaluateDockerComposeStatus determines if the host has the "docker compose" plugin or the "docker compose"
 // script installed and set the global `dockerCmd` variable.
-func EvaluateDockerComposeStatus() error {
+func EvaluateDockerComposeStatus() {
 	fmt.Println("[+] Checking the status of Docker and the Compose plugin...")
 	// Check for ``docker`` first because it's required for everything to come
 	dockerExists := CheckPath("docker")
@@ -88,8 +88,6 @@ func EvaluateDockerComposeStatus() error {
 	}
 
 	fmt.Println("[+] Docker and the Compose plugin checks have passed")
-
-	return nil
 }
 
 // DownloadDockerComposeFiles downloads production and development Docker Compose YAML files if confirmed by the user.

--- a/cmd/internal/docker.go
+++ b/cmd/internal/docker.go
@@ -91,8 +91,6 @@ func EvaluateDockerComposeStatus() {
 	fmt.Println("[+] Docker and the Compose plugin checks have passed")
 }
 
-// DownloadDockerComposeFiles downloads production and development Docker Compose YAML files if confirmed by the user.
-// Prompts the user before overwriting existing files in the current working directory.
 // DownloadDockerComposeFiles downloads the production and development Docker Compose YAML files into the BloodHound directory.
 // If either file already exists, prompts the user for confirmation before overwriting. Exits fatally on download failure.
 func DownloadDockerComposeFiles() {
@@ -134,7 +132,6 @@ func EvaluateEnvironment() {
 	DownloadDockerComposeFiles()
 }
 
-// RunDockerComposeInstall executes the "docker compose" commands for a first-time installation with
 // RunDockerComposeInstall performs a first-time installation of BloodHound containers using the specified Docker Compose YAML file.
 // It ensures required YAML files are present, pulls container images, and starts the environment in detached mode.
 // Prints login credentials and UI access information upon successful setup. Exits fatally on errors.
@@ -157,8 +154,10 @@ func RunDockerComposeInstall(yaml string) {
 	fmt.Printf("[+] You can access the BloodHound UI at: %s%s\n", bhEnv.GetString("root_url"), loginUri)
 }
 
-// RunDockerComposeUninstall executes the "docker compose" commands to bring down containers and remove containers,
-// RunDockerComposeUninstall removes all BloodHound containers, images, and volumes defined in the specified Docker Compose YAML file, then optionally deletes the BloodHound home directory after user confirmation. The process is interactive and exits if the user declines any confirmation prompt. Fatal errors are logged if uninstallation or directory deletion fails.
+// RunDockerComposeUninstall removes all BloodHound containers, images, and volumes defined in the specified Docker
+// Compose YAML file, then optionally deletes the BloodHound home directory after user confirmation. The process is
+// interactive and exits if the user declines any confirmation prompt. Fatal errors are logged if uninstallation or
+// directory deletion fails.
 func RunDockerComposeUninstall(yaml string) {
 	c := AskForConfirmation("[!] This command removes all containers, images, and volume data. Are you sure you want to uninstall?")
 	if !c {
@@ -188,7 +187,6 @@ func RunDockerComposeUninstall(yaml string) {
 	fmt.Println("[+] The home directory and config will be recreated if you continue using BloodHound CLI.")
 }
 
-// RunDockerComposeUpgrade executes the "docker compose" commands for re-building or upgrading an
 // RunDockerComposeUpgrade rebuilds and restarts all containers defined in the specified Docker Compose YAML file.
 // It brings down any running containers, rebuilds images, and brings the environment back up in detached mode.
 // Exits fatally if any Docker command fails.
@@ -210,7 +208,6 @@ func RunDockerComposeUpgrade(yaml string) {
 	fmt.Println("[+] All containers have been built!")
 }
 
-// RunDockerComposeStart executes the "docker compose" commands to start the environment with
 // RunDockerComposeStart starts all services defined in the specified Docker Compose YAML file.
 // Exits fatally if the YAML file does not exist or if starting the containers fails.
 func RunDockerComposeStart(yaml string) {
@@ -222,7 +219,6 @@ func RunDockerComposeStart(yaml string) {
 	}
 }
 
-// RunDockerComposeStop executes the "docker compose" commands to stop all services in the environment with
 // RunDockerComposeStop stops all services defined in the specified Docker Compose YAML file.
 // Exits the program if stopping services fails.
 func RunDockerComposeStop(yaml string) {
@@ -234,7 +230,6 @@ func RunDockerComposeStop(yaml string) {
 	}
 }
 
-// RunDockerComposeRestart executes the "docker compose" commands to restart the environment with
 // RunDockerComposeRestart restarts all containers defined in the specified Docker Compose YAML file.
 // Exits fatally if the YAML file does not exist or if the restart operation fails.
 func RunDockerComposeRestart(yaml string) {
@@ -246,8 +241,8 @@ func RunDockerComposeRestart(yaml string) {
 	}
 }
 
-// RunDockerComposeUp executes the "docker compose" commands to bring up the environment with
-// RunDockerComposeUp brings up Docker containers in detached mode using the specified Docker Compose YAML file. Exits fatally if the YAML file does not exist or if the command fails.
+// RunDockerComposeUp brings up Docker containers in detached mode using the specified Docker Compose YAML file.
+// Exits fatally if the YAML file does not exist or if the command fails.
 func RunDockerComposeUp(yaml string) {
 	fmt.Printf("[+] Running `%s` to bring up the containers with %s...\n", dockerCmd, yaml)
 	CheckYamlExists(yaml)
@@ -257,7 +252,6 @@ func RunDockerComposeUp(yaml string) {
 	}
 }
 
-// RunDockerComposeDown executes the "docker compose" commands to bring down the environment with
 // RunDockerComposeDown stops and removes containers defined in the specified Docker Compose YAML file.
 // If volumes is true, associated Docker volumes are also removed. Exits fatally on failure.
 func RunDockerComposeDown(yaml string, volumes bool) {

--- a/cmd/internal/docker.go
+++ b/cmd/internal/docker.go
@@ -96,7 +96,7 @@ func EvaluateDockerComposeStatus() error {
 // Prompts the user before overwriting existing files in the current working directory.
 // Requires overwriting confirmation for both prod and dev YAML files if they already exist.
 func DownloadDockerComposeFiles() {
-	workingDir := GetCwdFromExe()
+	workingDir := GetBloodHoundDir()
 	downloadProd := true
 	downloadDev := true
 	if FileExists(filepath.Join(workingDir, prodYaml)) {

--- a/cmd/internal/docker.go
+++ b/cmd/internal/docker.go
@@ -155,7 +155,7 @@ func RunDockerComposeInstall(yaml string) {
 }
 
 // RunDockerComposeUninstall removes all BloodHound containers, images, and volumes defined in the specified Docker
-// Compose YAML file, then optionally deletes the BloodHound home directory after user confirmation. The process is
+// Compose YAML file, then optionally deletes the BloodHound config directory after user confirmation. The process is
 // interactive and exits if the user declines any confirmation prompt. Fatal errors are logged if uninstallation or
 // directory deletion fails.
 func RunDockerComposeUninstall(yaml string) {
@@ -171,20 +171,20 @@ func RunDockerComposeUninstall(yaml string) {
 		log.Fatalf("Error trying to uninstall with %s: %v\n", yaml, uninstallErr)
 	}
 
-	dataDir := GetBloodHoundDir()
-	delConf := AskForConfirmation("[!] Do you want to also delete the home directory, " + dataDir + ", and its contents?")
+	configDir := GetBloodHoundDir()
+	delConf := AskForConfirmation("[!] Do you want to also delete the config directory, " + configDir + ", and its contents?")
 	if !delConf {
 		os.Exit(0)
 	}
 
-	delErr := os.RemoveAll(dataDir)
+	delErr := os.RemoveAll(configDir)
 	if delErr != nil {
-		log.Fatalf("Error trying to delete the home directory: %v\n", delErr)
+		log.Fatalf("Error trying to delete the config directory: %v\n", delErr)
 	} else {
-		fmt.Println("[+] Successfully deleted the BloodHound home directory!")
+		fmt.Println("[+] Successfully deleted the BloodHound config directory!")
 	}
 	fmt.Println("[+] Uninstall was successful. You can re-install with `./bloodhound-cli install`.")
-	fmt.Println("[+] The home directory and config will be recreated if you continue using BloodHound CLI.")
+	fmt.Println("[+] The config directory and JSON config file will be recreated if you continue using BloodHound CLI.")
 }
 
 // RunDockerComposeUpgrade rebuilds and restarts all containers defined in the specified Docker Compose YAML file.

--- a/cmd/internal/docker.go
+++ b/cmd/internal/docker.go
@@ -64,13 +64,13 @@ func EvaluateDockerComposeStatus() {
 	// Check for ``docker`` first because it's required for everything to come
 	dockerExists := CheckPath("docker")
 	if !dockerExists {
-		log.Fatalln("Docker is not installed on this system, so please install Docker and try again")
+		log.Fatalln("Docker is not installed on this system, so please install Docker and try again.")
 	}
 
 	// Check if the Docker Engine is running
 	_, engineErr := RunBasicCmd("docker", []string{"info"})
 	if engineErr != nil {
-		log.Fatalln("Docker is installed on this system, but the daemon is not running")
+		log.Fatalln("Docker is installed on this system, but the daemon is not running.")
 	}
 
 	// Check for the ``compose`` plugin as our first choice

--- a/cmd/internal/docker.go
+++ b/cmd/internal/docker.go
@@ -171,13 +171,13 @@ func RunDockerComposeUninstall(yaml string) {
 		log.Fatalf("Error trying to uninstall with %s: %v\n", yaml, uninstallErr)
 	}
 
-	homeDir := GetBloodHoundDir()
-	delConf := AskForConfirmation("[!] Do you want to also delete the home directory, " + homeDir + ", and its contents?")
+	dataDir := GetBloodHoundDir()
+	delConf := AskForConfirmation("[!] Do you want to also delete the home directory, " + dataDir + ", and its contents?")
 	if !delConf {
 		os.Exit(0)
 	}
 
-	delErr := os.RemoveAll(homeDir)
+	delErr := os.RemoveAll(dataDir)
 	if delErr != nil {
 		log.Fatalf("Error trying to delete the home directory: %v\n", delErr)
 	} else {

--- a/cmd/internal/docker.go
+++ b/cmd/internal/docker.go
@@ -140,6 +140,7 @@ func RunDockerComposeInstall(yaml string) {
 	// If the YAML files don't exist, download them from the BloodHound repo
 	DownloadDockerComposeFiles()
 
+	CheckYamlExists(yaml)
 	buildErr := RunCmd(dockerCmd, []string{"-f", yaml, "pull"})
 	if buildErr != nil {
 		log.Fatalf("Error trying to build with %s: %v\n", yaml, buildErr)
@@ -191,6 +192,7 @@ func RunDockerComposeUpgrade(yaml string) {
 // the specified YAML file ("yaml" parameter).
 func RunDockerComposeStart(yaml string) {
 	fmt.Printf("[+] Running `%s` to restart containers with %s...\n", dockerCmd, yaml)
+	CheckYamlExists(yaml)
 	startErr := RunCmd(dockerCmd, []string{"-f", yaml, "start"})
 	if startErr != nil {
 		log.Fatalf("Error trying to restart the containers with %s: %v\n", yaml, startErr)
@@ -201,6 +203,7 @@ func RunDockerComposeStart(yaml string) {
 // the specified YAML file ("yaml" parameter).
 func RunDockerComposeStop(yaml string) {
 	fmt.Printf("[+] Running `%s` to stop services with %s...\n", dockerCmd, yaml)
+	CheckYamlExists(yaml)
 	stopErr := RunCmd(dockerCmd, []string{"-f", yaml, "stop"})
 	if stopErr != nil {
 		log.Fatalf("Error trying to stop services with %s: %v\n", yaml, stopErr)
@@ -211,6 +214,7 @@ func RunDockerComposeStop(yaml string) {
 // the specified YAML file ("yaml" parameter).
 func RunDockerComposeRestart(yaml string) {
 	fmt.Printf("[+] Running `%s` to restart containers with %s...\n", dockerCmd, yaml)
+	CheckYamlExists(yaml)
 	startErr := RunCmd(dockerCmd, []string{"-f", yaml, "restart"})
 	if startErr != nil {
 		log.Fatalf("Error trying to restart the containers with %s: %v\n", yaml, startErr)
@@ -221,6 +225,7 @@ func RunDockerComposeRestart(yaml string) {
 // the specified YAML file ("yaml" parameter).
 func RunDockerComposeUp(yaml string) {
 	fmt.Printf("[+] Running `%s` to bring up the containers with %s...\n", dockerCmd, yaml)
+	CheckYamlExists(yaml)
 	upErr := RunCmd(dockerCmd, []string{"-f", yaml, "up", "-d"})
 	if upErr != nil {
 		log.Fatalf("Error trying to bring up the containers with %s: %v\n", yaml, upErr)
@@ -235,6 +240,7 @@ func RunDockerComposeDown(yaml string, volumes bool) {
 	if volumes {
 		args = append(args, "--volumes")
 	}
+	CheckYamlExists(yaml)
 	downErr := RunCmd(dockerCmd, args)
 	if downErr != nil {
 		log.Fatalf("Error trying to bring down the containers with %s: %v\n", yaml, downErr)
@@ -245,6 +251,7 @@ func RunDockerComposeDown(yaml string, volumes bool) {
 // the specified YAML file ("yaml" parameter).
 func RunDockerComposePull(yaml string) {
 	fmt.Printf("[+] Running `%s` to pull container imahes with %s...\n", dockerCmd, yaml)
+	CheckYamlExists(yaml)
 	startErr := RunCmd(dockerCmd, []string{"-f", yaml, "pull"})
 	if startErr != nil {
 		log.Fatalf("Error trying to pull the container images with %s: %v\n", yaml, startErr)

--- a/cmd/internal/docker.go
+++ b/cmd/internal/docker.go
@@ -59,12 +59,7 @@ func (c Containers) Swap(i, j int) {
 
 // EvaluateDockerComposeStatus determines if the host has the "docker compose" plugin or the "docker compose"
 // script installed and set the global `dockerCmd` variable.
-func EvaluateDockerComposeStatus(install ...bool) error {
-	isInstall := false
-	if len(install) > 0 {
-		isInstall = install[0]
-	}
-
+func EvaluateDockerComposeStatus() error {
 	fmt.Println("[+] Checking the status of Docker and the Compose plugin...")
 	// Check for ``docker`` first because it's required for everything to come
 	dockerExists := CheckPath("docker")
@@ -93,14 +88,6 @@ func EvaluateDockerComposeStatus(install ...bool) error {
 	}
 
 	fmt.Println("[+] Docker and the Compose plugin checks have passed")
-
-	// Bail out if we're not in the same directory as the YAML files
-	// Otherwise, we'll get a confusing error message from the `compose` plugin
-	if !isInstall {
-		if !FileExists(filepath.Join(GetCwdFromExe(), prodYaml)) || !FileExists(filepath.Join(GetCwdFromExe(), devYaml)) {
-			log.Fatalln("BloodHound CLI must be in the same directory as the `docker-compose.yml` and `docker-compose.dev.yml` files")
-		}
-	}
 
 	return nil
 }

--- a/cmd/internal/docker.go
+++ b/cmd/internal/docker.go
@@ -178,7 +178,7 @@ func RunDockerComposeUninstall(yaml string) {
 		os.Exit(0)
 	}
 
-	delErr := DeleteDir(homeDir)
+	delErr := os.RemoveAll(homeDir)
 	if delErr != nil {
 		log.Fatalf("Error trying to delete the home directory: %v\n", delErr)
 	} else {
@@ -273,11 +273,10 @@ func RunDockerComposeDown(yaml string, volumes bool) {
 	}
 }
 
-// RunDockerComposePull executes the "docker compose" commands to pull the latest container images for
 // RunDockerComposePull pulls the latest container images defined in the specified Docker Compose YAML file.
 // Exits fatally if the YAML file does not exist or if the pull operation fails.
 func RunDockerComposePull(yaml string) {
-	fmt.Printf("[+] Running `%s` to pull container imahes with %s...\n", dockerCmd, yaml)
+	fmt.Printf("[+] Running `%s` to pull container images with %s...\n", dockerCmd, yaml)
 	CheckYamlExists(yaml)
 	startErr := RunCmd(dockerCmd, []string{"-f", yaml, "pull"})
 	if startErr != nil {

--- a/cmd/internal/docker.go
+++ b/cmd/internal/docker.go
@@ -180,7 +180,7 @@ func RunDockerComposeUninstall(yaml string) {
 	if delErr != nil {
 		log.Fatalf("Error trying to delete the home directory: %v\n", delErr)
 	} else {
-		fmt.Println("[+] Successfully delete the BloodHound home directory!")
+		fmt.Println("[+] Successfully deleted the BloodHound home directory!")
 	}
 	fmt.Println("[+] Uninstall was successful. You can re-install with `./bloodhound-cli install`.")
 	fmt.Println("[+] The home directory and config will be recreated if you continue using BloodHound CLI.")

--- a/cmd/internal/docker_test.go
+++ b/cmd/internal/docker_test.go
@@ -9,13 +9,13 @@ import (
 
 func TestEvaluateDockerComposeStatus(t *testing.T) {
 	// Mock the BloodHound Docker YAML files
-	dataDir := GetDefaultDataDir()
-	err := os.MkdirAll(dataDir, 0755)
+	configDir := GetDefaultConfigDir()
+	err := os.MkdirAll(configDir, 0755)
 	assert.NoError(t, err, "Expected directory creation to succeed")
 
-	localMockYaml := filepath.Join(GetDefaultDataDir(), "docker-compose.dev.yml")
+	localMockYaml := filepath.Join(GetDefaultConfigDir(), "docker-compose.dev.yml")
 	local, localErr := os.Create(localMockYaml)
-	prodMockYaml := filepath.Join(GetDefaultDataDir(), "docker-compose.yml")
+	prodMockYaml := filepath.Join(GetDefaultConfigDir(), "docker-compose.yml")
 	prod, prodErr := os.Create(prodMockYaml)
 	assert.Equal(t, nil, localErr, "Expected `os.Create()` to return no error")
 	assert.Equal(t, nil, prodErr, "Expected `os.Create()` to return no error")

--- a/cmd/internal/docker_test.go
+++ b/cmd/internal/docker_test.go
@@ -9,13 +9,13 @@ import (
 
 func TestEvaluateDockerComposeStatus(t *testing.T) {
 	// Mock the BloodHound Docker YAML files
-	homeDir := GetDefaultHomeDir()
-	err := os.MkdirAll(homeDir, 0755)
+	dataDir := GetDefaultDataDir()
+	err := os.MkdirAll(dataDir, 0755)
 	assert.NoError(t, err, "Expected directory creation to succeed")
 
-	localMockYaml := filepath.Join(GetDefaultHomeDir(), "docker-compose.dev.yml")
+	localMockYaml := filepath.Join(GetDefaultDataDir(), "docker-compose.dev.yml")
 	local, localErr := os.Create(localMockYaml)
-	prodMockYaml := filepath.Join(GetDefaultHomeDir(), "docker-compose.yml")
+	prodMockYaml := filepath.Join(GetDefaultDataDir(), "docker-compose.yml")
 	prod, prodErr := os.Create(prodMockYaml)
 	assert.Equal(t, nil, localErr, "Expected `os.Create()` to return no error")
 	assert.Equal(t, nil, prodErr, "Expected `os.Create()` to return no error")

--- a/cmd/internal/docker_test.go
+++ b/cmd/internal/docker_test.go
@@ -9,9 +9,9 @@ import (
 
 func TestEvaluateDockerComposeStatus(t *testing.T) {
 	// Mock the BloodHound Docker YAML files
-	localMockYaml := filepath.Join(GetCwdFromExe(), "docker-compose.dev.yml")
+	localMockYaml := filepath.Join(GetDefaultHomeDir(), "docker-compose.dev.yml")
 	local, localErr := os.Create(localMockYaml)
-	prodMockYaml := filepath.Join(GetCwdFromExe(), "docker-compose.yml")
+	prodMockYaml := filepath.Join(GetDefaultHomeDir(), "docker-compose.yml")
 	prod, prodErr := os.Create(prodMockYaml)
 	assert.Equal(t, nil, localErr, "Expected `os.Create()` to return no error")
 	assert.Equal(t, nil, prodErr, "Expected `os.Create()` to return no error")

--- a/cmd/internal/docker_test.go
+++ b/cmd/internal/docker_test.go
@@ -24,7 +24,4 @@ func TestEvaluateDockerComposeStatus(t *testing.T) {
 
 	defer local.Close()
 	defer prod.Close()
-
-	result := EvaluateDockerComposeStatus()
-	assert.NoError(t, result, "Expected `EvaluateDockerComposeStatus()` to return no error")
 }

--- a/cmd/internal/docker_test.go
+++ b/cmd/internal/docker_test.go
@@ -9,6 +9,10 @@ import (
 
 func TestEvaluateDockerComposeStatus(t *testing.T) {
 	// Mock the BloodHound Docker YAML files
+	homeDir := GetDefaultHomeDir()
+	err := os.MkdirAll(homeDir, 0755)
+	assert.NoError(t, err, "Expected directory creation to succeed")
+
 	localMockYaml := filepath.Join(GetDefaultHomeDir(), "docker-compose.dev.yml")
 	local, localErr := os.Create(localMockYaml)
 	prodMockYaml := filepath.Join(GetDefaultHomeDir(), "docker-compose.yml")

--- a/cmd/internal/env.go
+++ b/cmd/internal/env.go
@@ -65,6 +65,8 @@ func setBloodHoundConfigDefaultValues() {
 
 	// Set some helpful aliases for common settings
 	bhEnv.RegisterAlias("default_password", "default_admin.password")
+
+	bhEnv.SetDefault("home_directory", GetDefaultHomeDir())
 }
 
 // WriteBloodHoundEnvironmentVariables writes the environment variables to the JSON config file.

--- a/cmd/internal/env.go
+++ b/cmd/internal/env.go
@@ -106,6 +106,15 @@ func checkJsonFileExistsAndCreate() {
 		if err := encoder.Encode(emptyJSON); err != nil {
 			log.Fatalf("Failed to write JSON to file: %v", err)
 		}
+	} else {
+		permCheck, permErr := CheckHomeDir(GetBloodHoundDir())
+		if permErr != nil {
+			log.Fatalf("Error checking the permissions on the home directory: %s", permErr)
+		}
+
+		if !permCheck {
+			log.Fatalf("The permissions set on the home directory, %s, should be at least 0700 (owner has full access and otehrs have no access)", GetBloodHoundDir())
+		}
 	}
 }
 

--- a/cmd/internal/env.go
+++ b/cmd/internal/env.go
@@ -113,7 +113,7 @@ func checkJsonFileExistsAndCreate() {
 		}
 
 		if !permCheck {
-			log.Fatalf("The permissions set on the home directory, %s, should be at least 0700 (owner has full access and otehrs have no access)", GetBloodHoundDir())
+			log.Fatalf("The permissions set on the home directory, %s, must be at least allow read and write for the current user (e.g., 0600).", GetBloodHoundDir())
 		}
 	}
 }

--- a/cmd/internal/env.go
+++ b/cmd/internal/env.go
@@ -171,6 +171,13 @@ func GetConfig(args []string) Configurations {
 
 // SetConfig sets the value of the specified key in the JSON config file.
 func SetConfig(key string, value string) {
+	// We do not support changing the `config_directory` at this time. We can explore that at a later time.
+	// Allowing it to be changed will cause the new directory to be created with a blank config file, so we disable the
+	// option here to avoid any confusion.
+	if strings.ToLower(key) == "config_directory" {
+		log.Fatalf("The config directory cannot be changed here, but you can use `--file` a different Docker YAML file to use.")
+	}
+
 	if strings.ToLower(value) == "true" {
 		bhEnv.Set(key, true)
 	} else if strings.ToLower(value) == "false" {
@@ -178,5 +185,6 @@ func SetConfig(key string, value string) {
 	} else {
 		bhEnv.Set(key, value)
 	}
+
 	WriteBloodHoundEnvironmentVariables()
 }

--- a/cmd/internal/env.go
+++ b/cmd/internal/env.go
@@ -78,9 +78,9 @@ func WriteBloodHoundEnvironmentVariables() {
 	}
 }
 
-// checkJsonFileExistsAndCreate checks if the JSON file exists and creates it with an empty value, {}, if it doesn't.
-// It also checks if the configured home directory exists, creates it if it does not, and then checks if the directory
-// checkJsonFileExistsAndCreate ensures that the BloodHound JSON configuration file exists in the designated directory with proper permissions, creating the file and home directory if necessary. If the file or directory cannot be created or permissions are insufficient, the function logs a fatal error and terminates the program.
+// checkJsonFileExistsAndCreate ensures that the BloodHound JSON configuration file exists in the designated directory
+// with proper permissions, creating the file and home directory if necessary. If the file or directory cannot be
+// created or permissions are insufficient, the function logs a fatal error and terminates the program.
 func checkJsonFileExistsAndCreate() {
 	if !FileExists(filepath.Join(GetBloodHoundDir(), "bloodhound.config.json")) {
 		homeErr := MakeHomeDir()
@@ -118,10 +118,9 @@ func checkJsonFileExistsAndCreate() {
 	}
 }
 
-// ParseBloodHoundEnvironmentVariables attempts to find and open an existing JSON config file or create a new one.
-// If a JSON config file is found, load it into the Viper configuration.
-// If a JSON config file is not found, create a new one with default values.
-// ParseBloodHoundEnvironmentVariables initializes default configuration values, ensures the BloodHound config file and directory exist with correct permissions, loads configuration from the JSON file and environment variables, and writes the final configuration back to the file. The function terminates the program on critical errors.
+// ParseBloodHoundEnvironmentVariables initializes default configuration values, ensures the BloodHound config file and
+// directory exist with correct permissions, loads configuration from the JSON file and environment variables, and
+// writes the final configuration back to the file. The function terminates the program on critical errors.
 func ParseBloodHoundEnvironmentVariables() {
 	setBloodHoundConfigDefaultValues()
 	bhEnv.SetConfigName("bloodhound.config.json")

--- a/cmd/internal/env.go
+++ b/cmd/internal/env.go
@@ -91,7 +91,7 @@ func checkJsonFileExistsAndCreate() {
 		file, err := os.Create(filepath.Join(GetBloodHoundDir(), "bloodhound.config.json"))
 
 		if err != nil {
-			log.Fatalf("The JSON config file doesn't exist and couldn't be created")
+			log.Fatalf("The JSON config file doesn't exist and couldn't be created.")
 		}
 
 		defer func(file *os.File) {
@@ -159,7 +159,7 @@ func GetConfig(args []string) Configurations {
 		setting := strings.ToLower(args[i])
 		val := bhEnv.GetString(setting)
 		if val == "" {
-			log.Fatalf("Config variable `%s` not found", setting)
+			log.Fatalf("Config variable `%s` not found.", setting)
 		} else {
 			values = append(values, Configuration{setting, val})
 		}

--- a/cmd/internal/env.go
+++ b/cmd/internal/env.go
@@ -66,7 +66,7 @@ func setBloodHoundConfigDefaultValues() {
 	// Set some helpful aliases for common settings
 	bhEnv.RegisterAlias("default_password", "default_admin.password")
 
-	bhEnv.SetDefault("data_directory", GetDefaultDataDir())
+	bhEnv.SetDefault("config_directory", GetDefaultConfigDir())
 }
 
 // WriteBloodHoundEnvironmentVariables writes the current BloodHound configuration to the JSON config file, ensuring the file exists before writing. Logs a fatal error and exits if writing fails.
@@ -79,13 +79,13 @@ func WriteBloodHoundEnvironmentVariables() {
 }
 
 // checkJsonFileExistsAndCreate ensures that the BloodHound JSON configuration file exists in the designated directory
-// with proper permissions, creating the file and home directory if necessary. If the file or directory cannot be
+// with proper permissions, creating the file and config directory if necessary. If the file or directory cannot be
 // created or permissions are insufficient, the function logs a fatal error and terminates the program.
 func checkJsonFileExistsAndCreate() {
 	if !FileExists(filepath.Join(GetBloodHoundDir(), "bloodhound.config.json")) {
-		homeErr := MakeDataDir()
-		if homeErr != nil {
-			log.Fatalf("Error creating home directory: %s", homeErr)
+		configErr := MakeConfigDir()
+		if configErr != nil {
+			log.Fatalf("Error creating config directory: %s", configErr)
 		}
 
 		file, err := os.Create(filepath.Join(GetBloodHoundDir(), "bloodhound.config.json"))
@@ -107,13 +107,13 @@ func checkJsonFileExistsAndCreate() {
 			log.Fatalf("Failed to write JSON to file: %v", err)
 		}
 	} else {
-		permCheck, permErr := CheckDataDir(GetBloodHoundDir())
+		permCheck, permErr := CheckConfigDir(GetBloodHoundDir())
 		if permErr != nil {
-			log.Fatalf("Error checking the permissions on the home directory: %s", permErr)
+			log.Fatalf("Error checking the permissions on the config directory: %s", permErr)
 		}
 
 		if !permCheck {
-			log.Fatalf("The permissions set on the home directory, %s, must be at least allow read and write for the current user (e.g., 0600).", GetBloodHoundDir())
+			log.Fatalf("The permissions set on the config directory, %s, must be at least allow read and write for the current user (e.g., 0600).", GetBloodHoundDir())
 		}
 	}
 }

--- a/cmd/internal/env.go
+++ b/cmd/internal/env.go
@@ -126,9 +126,9 @@ func ParseBloodHoundEnvironmentVariables() {
 	setBloodHoundConfigDefaultValues()
 	bhEnv.SetConfigName("bloodhound.config.json")
 	bhEnv.SetConfigType("json")
-	bhEnv.AddConfigPath(GetCwdFromExe())
+	bhEnv.AddConfigPath(GetBloodHoundDir())
 	bhEnv.AutomaticEnv()
-	// Check if expected JSON file exists
+	// Check if the expected JSON file exists
 	checkJsonFileExistsAndCreate()
 	// Try reading the env file
 	if err := bhEnv.ReadInConfig(); err != nil {

--- a/cmd/internal/env.go
+++ b/cmd/internal/env.go
@@ -79,9 +79,16 @@ func WriteBloodHoundEnvironmentVariables() {
 }
 
 // checkJsonFileExistsAndCreate checks if the JSON file exists and creates it with an empty value, {}, if it doesn't.
+// It also checks if the configured home directory exists, creates it if it does not, and then checks if the directory
+// has the correct minimum permissions.
 func checkJsonFileExistsAndCreate() {
-	if !FileExists(filepath.Join(GetCwdFromExe(), "bloodhound.config.json")) {
-		file, err := os.Create(filepath.Join(GetCwdFromExe(), "bloodhound.config.json"))
+	if !FileExists(filepath.Join(GetBloodHoundDir(), "bloodhound.config.json")) {
+		homeErr := MakeHomeDir()
+		if homeErr != nil {
+			log.Fatalf("Error creating home directory: %s", homeErr)
+		}
+
+		file, err := os.Create(filepath.Join(GetBloodHoundDir(), "bloodhound.config.json"))
 
 		if err != nil {
 			log.Fatalf("The JSON config file doesn't exist and couldn't be created")

--- a/cmd/internal/env.go
+++ b/cmd/internal/env.go
@@ -66,7 +66,7 @@ func setBloodHoundConfigDefaultValues() {
 	// Set some helpful aliases for common settings
 	bhEnv.RegisterAlias("default_password", "default_admin.password")
 
-	bhEnv.SetDefault("home_directory", GetDefaultHomeDir())
+	bhEnv.SetDefault("data_directory", GetDefaultDataDir())
 }
 
 // WriteBloodHoundEnvironmentVariables writes the current BloodHound configuration to the JSON config file, ensuring the file exists before writing. Logs a fatal error and exits if writing fails.
@@ -83,7 +83,7 @@ func WriteBloodHoundEnvironmentVariables() {
 // created or permissions are insufficient, the function logs a fatal error and terminates the program.
 func checkJsonFileExistsAndCreate() {
 	if !FileExists(filepath.Join(GetBloodHoundDir(), "bloodhound.config.json")) {
-		homeErr := MakeHomeDir()
+		homeErr := MakeDataDir()
 		if homeErr != nil {
 			log.Fatalf("Error creating home directory: %s", homeErr)
 		}
@@ -107,7 +107,7 @@ func checkJsonFileExistsAndCreate() {
 			log.Fatalf("Failed to write JSON to file: %v", err)
 		}
 	} else {
-		permCheck, permErr := CheckHomeDir(GetBloodHoundDir())
+		permCheck, permErr := CheckDataDir(GetBloodHoundDir())
 		if permErr != nil {
 			log.Fatalf("Error checking the permissions on the home directory: %s", permErr)
 		}

--- a/cmd/internal/env_test.go
+++ b/cmd/internal/env_test.go
@@ -22,8 +22,9 @@ func TestBloodHoundEnvironmentVariables(t *testing.T) {
 	//defer quietTests()()
 
 	// Test parsing values and writing to the JSON config file
-	envFile := filepath.Join(GetCwdFromExe(), "bloodhound.config.json")
 	ParseBloodHoundEnvironmentVariables()
+	envFile := filepath.Join(GetBloodHoundDir(), "bloodhound.config.json")
+
 	assert.True(t, FileExists(envFile), "Expected the JSON file to exist")
 
 	// Test a default value
@@ -40,7 +41,7 @@ func TestBloodHoundEnvironmentVariables(t *testing.T) {
 	assert.Equal(t, len(format), 2, "`GetConfig()` with two valid variables should return a two values")
 
 	// Test ``GetConfigAll()``
-	assert.Equal(t, 12, CountConfigProperties(), "`GetConfigAll()` should return all values")
+	assert.Equal(t, 13, CountConfigProperties(), "`GetConfigAll()` should return all values")
 
 	// Test ``SetConfig()``
 	SetConfig("log_path", "bhce.log")

--- a/cmd/internal/passwords.go
+++ b/cmd/internal/passwords.go
@@ -22,7 +22,7 @@ func GenerateRandomPassword(pwLength int, safe bool) string {
 	for i := 0; i < pwLength; i++ {
 		nBig, err := rand.Int(rand.Reader, big.NewInt(int64(len(chars))))
 		if err != nil {
-			log.Fatalf("Failed to generate random number for password generation\n")
+			log.Fatalf("Failed to generate random number for password generation.\n")
 		}
 		b.WriteRune(chars[nBig.Int64()])
 	}

--- a/cmd/internal/utils.go
+++ b/cmd/internal/utils.go
@@ -80,7 +80,7 @@ func GetBloodHoundDir() string {
 	return bhEnv.GetString("config_directory")
 }
 
-// MakeConfigDir ensures the configured BloodHound config directory exists, creating it with permissions 0777 if necessary.
+// MakeConfigDir ensures the configured BloodHound config directory exists, creating it if necessary.
 // Returns an error if directory creation fails.
 func MakeConfigDir() error {
 	configDir := GetBloodHoundDir()
@@ -91,7 +91,6 @@ func MakeConfigDir() error {
 			return mkErr
 		}
 		log.Println("Successfully created the BloodHound config directory.")
-		log.Println("Note: The directory is open to all users (mask 0777). If you will be the only user, feel free to make adjustments.")
 	}
 
 	return nil

--- a/cmd/internal/utils.go
+++ b/cmd/internal/utils.go
@@ -58,7 +58,6 @@ func FileExists(path string) bool {
 	return !info.IsDir()
 }
 
-// DirExists determines if a given string is a valid directory.
 // DirExists reports whether the specified path exists and is a directory. Returns false if the path does not exist.
 func DirExists(path string) bool {
 	info, err := os.Stat(path)
@@ -128,7 +127,6 @@ func CheckYamlExists(path string) {
 	}
 }
 
-// CheckPath checks the $PATH environment variable for a given "cmd" and return a "bool"
 // CheckPath returns true if the specified command exists in the system's PATH.
 func CheckPath(cmd string) bool {
 	_, err := exec.LookPath(cmd)

--- a/cmd/internal/utils.go
+++ b/cmd/internal/utils.go
@@ -40,7 +40,7 @@ func (c HealthIssues) Swap(i, j int) {
 func GetCwdFromExe() string {
 	exe, err := os.Executable()
 	if err != nil {
-		log.Fatalf("Failed to get path to current executable")
+		log.Fatalf("Failed to get path to current executable.")
 	}
 	return filepath.Dir(exe)
 }
@@ -170,7 +170,7 @@ func RunCmd(name string, args []string) error {
 	}
 	exe, err := os.Executable()
 	if err != nil {
-		log.Fatalf("Failed to get path to current executable")
+		log.Fatalf("Failed to get path to current executable.")
 	}
 	exePath := filepath.Dir(exe)
 	command := exec.Command(path, args...)

--- a/cmd/internal/utils.go
+++ b/cmd/internal/utils.go
@@ -81,28 +81,28 @@ func GetDefaultHomeDir() string {
 
 // GetBloodHoundDir returns the full path configured as the home directory.
 func GetBloodHoundDir() string {
-	homeDir := bhEnv.GetString("home_directory")
-	return filepath.Join(homeDir)
+	return bhEnv.GetString("home_directory")
 }
 
-// MakeHomeDir checks if the configured home directory exists and creates it if it does not.
+// MakeHomeDir checks if the configured home directory exists and creates it if it does not. The directory is created
+// with permissions set to 0700.
 func MakeHomeDir() error {
 	homeDir := GetBloodHoundDir()
 	if !DirExists(homeDir) {
-		log.Printf("The configured BloodHound home directory, %s, is missing, so attempting to create it\n", homeDir)
-		mkErr := os.MkdirAll(homeDir, 0600)
+		log.Printf("The configured BloodHound home directory, %s, is missing, so attempting to create it.\n", homeDir)
+		mkErr := os.MkdirAll(homeDir, 0777)
 		if mkErr != nil {
 			return mkErr
 		}
-		log.Println("Successfully created the BloodHound home directory")
+		log.Println("Successfully created the BloodHound home directory.")
+		log.Println("Note: The directory is open to all users (mask 0777). If you will be the only user, feel free to make adjustments.")
 	}
 
 	return nil
 }
 
-// CheckHomeDir checks if the home directory's permissions are at least 0600. This ensures the current user has full
-// access and no other users have access. This is intended as a secure baseline. A more permissive permissions set won't
-// trigger any errors.
+// CheckHomeDir checks if the home directory's permissions are at least 0600. This ensures the current user has R/W
+// access and BloodHound CLI can function. A more permissive mode won't trigger any errors.
 func CheckHomeDir(path string) (bool, error) {
 	info, err := os.Stat(path)
 	if err != nil {

--- a/cmd/internal/utils.go
+++ b/cmd/internal/utils.go
@@ -6,6 +6,7 @@ package internal
 import (
 	"bufio"
 	"fmt"
+	"github.com/adrg/xdg"
 	"io"
 	"log"
 	"net/http"
@@ -72,11 +73,7 @@ func DirExists(path string) bool {
 // GetDefaultHomeDir returns the path for the default BloodHound home directory for initial config creation.
 // The initial path will always be a hidden `.BloodHound` directory inside the current user's home directory.
 func GetDefaultHomeDir() string {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		log.Fatalf("Failed to get user's home directory path to set default home directory: %v", err)
-	}
-	return filepath.Join(homeDir, ".BloodHound")
+	return filepath.Join(xdg.DataHome, ".BloodHound")
 }
 
 // GetBloodHoundDir returns the full path configured as the home directory.

--- a/cmd/internal/utils.go
+++ b/cmd/internal/utils.go
@@ -126,6 +126,11 @@ func DeleteDir(path string) error {
 	return nil
 }
 
+// GetYamlFilePath joins and returns the directory path of the BloodHound home directory with the Docker Compose YAML file.
+func GetYamlFilePath() string {
+	return filepath.Join(GetBloodHoundDir(), "docker-compose.yml")
+}
+
 // CheckYamlExists determines if the specified file exists and logs a fatal warning if it does not. It is a wrapper for
 // the `FileExists` function and is intended to check YAML files just before executing Docker commands.
 func CheckYamlExists(path string) {

--- a/cmd/internal/utils.go
+++ b/cmd/internal/utils.go
@@ -69,38 +69,38 @@ func DirExists(path string) bool {
 	return info.IsDir()
 }
 
-// GetDefaultDataDir returns the default BloodHound data directory path as a `bloodhound` folder inside the current user's data directory.
-// Logs a fatal error if the user's home directory cannot be determined.
-func GetDefaultDataDir() string {
+// GetDefaultConfigDir returns the default BloodHound config directory path as a `bloodhound` folder inside the current user's data directory.
+// Logs a fatal error if the user's config directory cannot be determined.
+func GetDefaultConfigDir() string {
 	return filepath.Join(xdg.ConfigHome, "bloodhound")
 }
 
-// GetBloodHoundDir returns the configured BloodHound home directory path from the environment variable "data_directory".
+// GetBloodHoundDir returns the configured BloodHound config directory path from the environment variable "config_directory".
 func GetBloodHoundDir() string {
-	return bhEnv.GetString("data_directory")
+	return bhEnv.GetString("config_directory")
 }
 
-// MakeDataDir ensures the configured BloodHound data directory exists, creating it with permissions 0777 if necessary.
+// MakeConfigDir ensures the configured BloodHound config directory exists, creating it with permissions 0777 if necessary.
 // Returns an error if directory creation fails.
-func MakeDataDir() error {
-	dataDir := GetBloodHoundDir()
-	if !DirExists(dataDir) {
-		log.Printf("The configured BloodHound home directory, %s, is missing, so attempting to create it.\n", dataDir)
-		mkErr := os.MkdirAll(dataDir, 0777)
+func MakeConfigDir() error {
+	configDir := GetBloodHoundDir()
+	if !DirExists(configDir) {
+		log.Printf("The BloodHound config directory you have set, %s, is missing, so attempting to create it.\n", configDir)
+		mkErr := os.MkdirAll(configDir, 0777)
 		if mkErr != nil {
 			return mkErr
 		}
-		log.Println("Successfully created the BloodHound home directory.")
+		log.Println("Successfully created the BloodHound config directory.")
 		log.Println("Note: The directory is open to all users (mask 0777). If you will be the only user, feel free to make adjustments.")
 	}
 
 	return nil
 }
 
-// CheckDataDir checks if the data directory's permissions are at least 0600. This ensures the current user has R/W
+// CheckConfigDir checks if the config directory's permissions are at least 0600. This ensures the current user has R/W
 // access and BloodHound CLI can function. A more permissive mode won't trigger any errors.
 // It returns true if the permissions are sufficient, along with any error encountered during the stat operation.
-func CheckDataDir(path string) (bool, error) {
+func CheckConfigDir(path string) (bool, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return false, err
@@ -110,7 +110,7 @@ func CheckDataDir(path string) (bool, error) {
 	return mode&baselinePerms == baselinePerms, nil
 }
 
-// GetYamlFilePath joins and returns the directory path of the BloodHound home directory with the Docker Compose YAML file.
+// GetYamlFilePath joins and returns the directory path of the BloodHound config directory with the Docker Compose YAML file.
 func GetYamlFilePath() string {
 	return filepath.Join(GetBloodHoundDir(), "docker-compose.yml")
 }
@@ -120,7 +120,7 @@ func GetYamlFilePath() string {
 func CheckYamlExists(path string) {
 	if !FileExists(path) {
 		log.Fatalf(
-			"The YAML file %s does not exist! To continue, move your YAML file into the home directory or run "+
+			"The YAML file %s does not exist! To continue, move your YAML file into the config directory or run "+
 				"`./bloodhound-cli check` to download the necessary YAML file.",
 			path)
 	}

--- a/cmd/internal/utils.go
+++ b/cmd/internal/utils.go
@@ -110,7 +110,27 @@ func CheckConfigDir(path string) (bool, error) {
 }
 
 // GetYamlFilePath joins and returns the directory path of the BloodHound config directory with the Docker Compose YAML file.
-func GetYamlFilePath() string {
+// If a user has provided the `-f` or `--file` flag with a string value, the function will return that filepath.
+func GetYamlFilePath(override string) string {
+	if override != "" {
+		log.Printf("Using the override filepath: %s", override)
+		fileInfo, err := os.Stat(override)
+		if err != nil {
+			if os.IsNotExist(err) {
+				log.Fatalf("The override path '%s' does not exist.\n", override)
+			} else {
+				log.Fatalf("There was an error checking the override path '%s': %v\n", override, err)
+			}
+		}
+		if fileInfo.IsDir() {
+			log.Fatalf("The provided override path '%s' is a directory instead of a YAML file.\n", override)
+		} else {
+			if !FileExists(override) {
+				log.Fatalf("Override filepaths does not exist: %s", override)
+			}
+		}
+		return override
+	}
 	return filepath.Join(GetBloodHoundDir(), "docker-compose.yml")
 }
 

--- a/cmd/internal/utils.go
+++ b/cmd/internal/utils.go
@@ -69,24 +69,24 @@ func DirExists(path string) bool {
 	return info.IsDir()
 }
 
-// GetDefaultHomeDir returns the default BloodHound home directory path as a hidden `.BloodHound` folder inside the current user's home directory.
+// GetDefaultDataDir returns the default BloodHound data directory path as a `bloodhound` folder inside the current user's data directory.
 // Logs a fatal error if the user's home directory cannot be determined.
-func GetDefaultHomeDir() string {
-	return filepath.Join(xdg.ConfigHome, "BloodHound")
+func GetDefaultDataDir() string {
+	return filepath.Join(xdg.ConfigHome, "bloodhound")
 }
 
-// GetBloodHoundDir returns the configured BloodHound home directory path from the environment variable "home_directory".
+// GetBloodHoundDir returns the configured BloodHound home directory path from the environment variable "data_directory".
 func GetBloodHoundDir() string {
-	return bhEnv.GetString("home_directory")
+	return bhEnv.GetString("data_directory")
 }
 
-// MakeHomeDir ensures the configured BloodHound home directory exists, creating it with permissions 0777 if necessary.
+// MakeDataDir ensures the configured BloodHound data directory exists, creating it with permissions 0777 if necessary.
 // Returns an error if directory creation fails.
-func MakeHomeDir() error {
-	homeDir := GetBloodHoundDir()
-	if !DirExists(homeDir) {
-		log.Printf("The configured BloodHound home directory, %s, is missing, so attempting to create it.\n", homeDir)
-		mkErr := os.MkdirAll(homeDir, 0777)
+func MakeDataDir() error {
+	dataDir := GetBloodHoundDir()
+	if !DirExists(dataDir) {
+		log.Printf("The configured BloodHound home directory, %s, is missing, so attempting to create it.\n", dataDir)
+		mkErr := os.MkdirAll(dataDir, 0777)
 		if mkErr != nil {
 			return mkErr
 		}
@@ -97,10 +97,10 @@ func MakeHomeDir() error {
 	return nil
 }
 
-// CheckHomeDir checks if the home directory's permissions are at least 0600. This ensures the current user has R/W
+// CheckDataDir checks if the data directory's permissions are at least 0600. This ensures the current user has R/W
 // access and BloodHound CLI can function. A more permissive mode won't trigger any errors.
 // It returns true if the permissions are sufficient, along with any error encountered during the stat operation.
-func CheckHomeDir(path string) (bool, error) {
+func CheckDataDir(path string) (bool, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return false, err
@@ -133,7 +133,7 @@ func CheckPath(cmd string) bool {
 }
 
 // RunBasicCmd executes a given command ("name") with a list of arguments ("args")
-// and return a "string" with the output.
+// and returns a "string" with the output.
 func RunBasicCmd(name string, args []string) (string, error) {
 	out, err := exec.Command(name, args...).Output()
 	output := string(out[:])

--- a/cmd/internal/utils.go
+++ b/cmd/internal/utils.go
@@ -69,11 +69,10 @@ func DirExists(path string) bool {
 	return info.IsDir()
 }
 
-// GetDefaultHomeDir returns the path for the default BloodHound home directory for initial config creation.
 // GetDefaultHomeDir returns the default BloodHound home directory path as a hidden `.BloodHound` folder inside the current user's home directory.
 // Logs a fatal error if the user's home directory cannot be determined.
 func GetDefaultHomeDir() string {
-	return filepath.Join(xdg.DataHome, ".BloodHound")
+	return filepath.Join(xdg.ConfigHome, "BloodHound")
 }
 
 // GetBloodHoundDir returns the configured BloodHound home directory path from the environment variable "home_directory".

--- a/cmd/internal/utils.go
+++ b/cmd/internal/utils.go
@@ -90,7 +90,7 @@ func MakeHomeDir() error {
 	homeDir := GetBloodHoundDir()
 	if !DirExists(homeDir) {
 		log.Printf("The configured BloodHound home directory, %s, is missing, so attempting to create it\n", homeDir)
-		mkErr := os.MkdirAll(homeDir, 0700)
+		mkErr := os.MkdirAll(homeDir, 0600)
 		if mkErr != nil {
 			return mkErr
 		}
@@ -100,7 +100,7 @@ func MakeHomeDir() error {
 	return nil
 }
 
-// CheckHomeDir checks if the home directory's permissions are at least 0700. This ensures the current user has full
+// CheckHomeDir checks if the home directory's permissions are at least 0600. This ensures the current user has full
 // access and no other users have access. This is intended as a secure baseline. A more permissive permissions set won't
 // trigger any errors.
 func CheckHomeDir(path string) (bool, error) {
@@ -108,7 +108,7 @@ func CheckHomeDir(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	baselinePerms := os.FileMode(0700)
+	baselinePerms := os.FileMode(0600)
 	mode := info.Mode().Perm()
 	return mode&baselinePerms == baselinePerms, nil
 }

--- a/cmd/internal/utils.go
+++ b/cmd/internal/utils.go
@@ -113,16 +113,14 @@ func CheckHomeDir(path string) (bool, error) {
 	return mode&baselinePerms == baselinePerms, nil
 }
 
-// DeleteHomeDir deletes the configured home directory and all contents. This is intended as the final step of the
+// DeleteDir deletes the configured home directory and all contents. This is intended as the final step of the
 // `uninstall` command.
-func DeleteHomeDir(path string) error {
-	homeDir := bhEnv.GetString("home_directory")
-	if DirExists(homeDir) {
-		delErr := os.RemoveAll(homeDir)
+func DeleteDir(path string) error {
+	if DirExists(path) {
+		delErr := os.RemoveAll(path)
 		if delErr != nil {
 			return delErr
 		}
-		log.Println("Successfully delete the BloodHound home directory")
 	}
 
 	return nil

--- a/cmd/internal/utils.go
+++ b/cmd/internal/utils.go
@@ -112,26 +112,11 @@ func CheckHomeDir(path string) (bool, error) {
 	return mode&baselinePerms == baselinePerms, nil
 }
 
-// DeleteDir deletes the configured home directory and all contents. This is intended as the final step of the
-// DeleteDir removes the directory at the specified path and all its contents if it exists.
-// Returns any error encountered during removal.
-func DeleteDir(path string) error {
-	if DirExists(path) {
-		delErr := os.RemoveAll(path)
-		if delErr != nil {
-			return delErr
-		}
-	}
-
-	return nil
-}
-
 // GetYamlFilePath joins and returns the directory path of the BloodHound home directory with the Docker Compose YAML file.
 func GetYamlFilePath() string {
 	return filepath.Join(GetBloodHoundDir(), "docker-compose.yml")
 }
 
-// CheckYamlExists determines if the specified file exists and logs a fatal warning if it does not. It is a wrapper for
 // CheckYamlExists verifies that a YAML file exists at the specified path.
 // If the file does not exist, it logs a fatal error with instructions for obtaining the required YAML file.
 func CheckYamlExists(path string) {

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	docker "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
+	"path/filepath"
 )
 
 // resetPwdCmd represents the resetpwd command
@@ -31,10 +32,10 @@ func init() {
 }
 
 func resetAdminPwd(cmd *cobra.Command, args []string) {
-	err := docker.EvaluateDockerComposeStatus(true)
+	err := docker.EvaluateDockerComposeStatus()
 	if err != nil {
 		return
 	}
 	fmt.Println("[+] Resetting admin password")
-	docker.ResetAdminPassword("docker-compose.yml")
+	docker.ResetAdminPassword(filepath.Join(docker.GetBloodHoundDir(), "docker-compose.yml"))
 }

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -35,5 +35,5 @@ func init() {
 func resetAdminPwd(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Resetting admin password")
-	docker.ResetAdminPassword(docker.GetYamlFilePath(dirOverride))
+	docker.ResetAdminPassword(docker.GetYamlFilePath(fileOverride))
 }

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	docker "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
-	"path/filepath"
 )
 
 // resetPwdCmd represents the resetpwd command
@@ -37,5 +36,5 @@ func resetAdminPwd(cmd *cobra.Command, args []string) {
 		return
 	}
 	fmt.Println("[+] Resetting admin password")
-	docker.ResetAdminPassword(filepath.Join(docker.GetBloodHoundDir(), "docker-compose.yml"))
+	docker.ResetAdminPassword(docker.GetYamlFilePath())
 }

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -31,10 +31,7 @@ func init() {
 }
 
 func resetAdminPwd(cmd *cobra.Command, args []string) {
-	err := docker.EvaluateDockerComposeStatus()
-	if err != nil {
-		return
-	}
+	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Resetting admin password")
 	docker.ResetAdminPassword(docker.GetYamlFilePath())
 }

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -35,5 +35,5 @@ func init() {
 func resetAdminPwd(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Resetting admin password")
-	docker.ResetAdminPassword(docker.GetYamlFilePath())
+	docker.ResetAdminPassword(docker.GetYamlFilePath(dirOverride))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Vars for global flags
-var dirOverride string
+var fileOverride string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -30,5 +30,5 @@ func init() {
 	// Create or parse the Docker ``bloodhound.config.json`` file
 	env.ParseBloodHoundEnvironmentVariables()
 
-	rootCmd.PersistentFlags().StringVarP(&dirOverride, "file", "f", "", `Override the YAML file in the configured data directory and use a different YAML file for the container commands.`)
+	rootCmd.PersistentFlags().StringVarP(&fileOverride, "file", "f", "", `Override the YAML file in the configured data directory and use a different YAML file for the container commands.`)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,9 @@ import (
 	"os"
 )
 
+// Vars for global flags
+var dirOverride string
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "bloodhound-cli",
@@ -26,4 +29,6 @@ func Execute() {
 func init() {
 	// Create or parse the Docker ``bloodhound.config.json`` file
 	env.ParseBloodHoundEnvironmentVariables()
+
+	rootCmd.PersistentFlags().StringVarP(&dirOverride, "file", "f", "", `Override the YAML file in the configured data directory and use a different YAML file for the container commands.`)
 }

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	docker "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
+	"path/filepath"
 )
 
 // installCmd represents the install command
@@ -34,5 +35,5 @@ func uninstallBloodHound(cmd *cobra.Command, args []string) {
 		return
 	}
 	fmt.Println("[+] Starting BloodHound environment removal")
-	docker.RunDockerComposeUninstall("docker-compose.yml")
+	docker.RunDockerComposeUninstall(filepath.Join(docker.GetBloodHoundDir(), "docker-compose.yml"))
 }

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -33,5 +33,5 @@ func init() {
 func uninstallBloodHound(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Starting BloodHound environment removal")
-	docker.RunDockerComposeUninstall(docker.GetYamlFilePath(dirOverride))
+	docker.RunDockerComposeUninstall(docker.GetYamlFilePath(fileOverride))
 }

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	docker "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
-	"path/filepath"
 )
 
 // installCmd represents the install command
@@ -35,5 +34,5 @@ func uninstallBloodHound(cmd *cobra.Command, args []string) {
 		return
 	}
 	fmt.Println("[+] Starting BloodHound environment removal")
-	docker.RunDockerComposeUninstall(filepath.Join(docker.GetBloodHoundDir(), "docker-compose.yml"))
+	docker.RunDockerComposeUninstall(docker.GetYamlFilePath())
 }

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -29,10 +29,7 @@ func init() {
 }
 
 func uninstallBloodHound(cmd *cobra.Command, args []string) {
-	err := docker.EvaluateDockerComposeStatus()
-	if err != nil {
-		return
-	}
+	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Starting BloodHound environment removal")
 	docker.RunDockerComposeUninstall(docker.GetYamlFilePath())
 }

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -33,5 +33,5 @@ func init() {
 func uninstallBloodHound(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Starting BloodHound environment removal")
-	docker.RunDockerComposeUninstall(docker.GetYamlFilePath())
+	docker.RunDockerComposeUninstall(docker.GetYamlFilePath(dirOverride))
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -22,5 +22,5 @@ func init() {
 func updateBloodHound(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Checking for BloodHound image updates...")
-	docker.RunDockerComposePull(docker.GetYamlFilePath(dirOverride))
+	docker.RunDockerComposePull(docker.GetYamlFilePath(fileOverride))
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	docker "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
-	"path/filepath"
 )
 
 // updateCmd represents the update command
@@ -25,5 +24,5 @@ func updateBloodHound(cmd *cobra.Command, args []string) {
 		return
 	}
 	fmt.Println("[+] Checking for BloodHound image updates...")
-	docker.RunDockerComposePull(filepath.Join(docker.GetBloodHoundDir(), "docker-compose.yml"))
+	docker.RunDockerComposePull(docker.GetYamlFilePath())
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -22,5 +22,5 @@ func init() {
 func updateBloodHound(cmd *cobra.Command, args []string) {
 	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Checking for BloodHound image updates...")
-	docker.RunDockerComposePull(docker.GetYamlFilePath())
+	docker.RunDockerComposePull(docker.GetYamlFilePath(dirOverride))
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	docker "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
+	"path/filepath"
 )
 
 // updateCmd represents the update command
@@ -24,5 +25,5 @@ func updateBloodHound(cmd *cobra.Command, args []string) {
 		return
 	}
 	fmt.Println("[+] Checking for BloodHound image updates...")
-	docker.RunDockerComposePull("docker-compose.yml")
+	docker.RunDockerComposePull(filepath.Join(docker.GetBloodHoundDir(), "docker-compose.yml"))
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -19,10 +19,7 @@ func init() {
 }
 
 func updateBloodHound(cmd *cobra.Command, args []string) {
-	err := docker.EvaluateDockerComposeStatus()
-	if err != nil {
-		return
-	}
+	docker.EvaluateDockerComposeStatus()
 	fmt.Println("[+] Checking for BloodHound image updates...")
 	docker.RunDockerComposePull(docker.GetYamlFilePath())
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -19,5 +19,5 @@ func init() {
 }
 
 func displayVersion(cmd *cobra.Command, args []string) {
-	fmt.Printf("BloodHound-CLI ( %s, %s )\n", config.Version, config.BuildDate)
+	fmt.Printf("BloodHound-CLI (%s, %s)\n", config.Version, config.BuildDate)
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 
 require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
+	github.com/adrg/xdg v0.5.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
+github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=


### PR DESCRIPTION
# Summary

This PR adds support for a dedicated home directory for BloodHound CLI. The CHANGELOG contains the detailed changes. This is intended to make it easy to place the binary anywhere on a system and run it from any working directory while keeping the JSON configuration file and Docker YAML files in one place for easy maintenance.

# CHANGELOG

## [0.1.7] - 2025-7-1

### Added

* Added support for a dedicated config directory to act as the configuration home for the JSON configuration file and default Docker YAML files
  * The directory is the user's XDG config home directory and `bloodhound`
      * i.e., the equivalent of `~/.config/bloodhound` on Unix, \
        `~/Library/Application Support/bloodhound` on macOS, and \
        `%LOCALAPPDATA%\bloodhound` on Windows
      * We use a lowercase `bloodhound` to match the directory used by older installations of BloodHound
    * You can place BloodHound CLI anywhere and run it from any location, and it will always look in the config directory for the JSON and default YAML files
    * The CLI creates the directory with a `0777` permissions mask so it is accessible to all BloodHound users in multi-user environments
    * The permissions follow your [umask](https://man7.org/linux/man-pages/man2/umask.2.html), so the typical user mask of `0022` will set the permissions to `0755`
* Added a `config_directory` value to the JSON configuration file to control the config directory path
  * Changing this path will change where BloodHound CLI looks for the Docker YAML files
  * BloodHound CLI will continue to look in the default location for the JSON config file 
* Added checks that ensure the configured directory will work as expected every time BloodHound CLI runs
  * The first check ensures the directory exists and creates the directory if it does not
  * The second check ensures the config directory has proper permissions that will allow BloodHound CLI to read and write
* Added a `-f` or `--file` flag to override the location of the YAML file to use for Docker
  * Providing a file path will override where BloodHound CLI looks for the YAML file
  * e.g., `./bloodhound-cli -f /Users/Mable/BloodHound/custom-docker-compose.yml containers up`

### Changed

* Every command that runs a Docker command will now ensure the required YAML file exists before proceeding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for a dedicated configuration directory for storing JSON config and Docker YAML files, enabling CLI usage from any location.
  * Introduced a configurable config directory path, defaulting to XDG-compliant locations like `~/.config/bloodhound`.
  * Added a new CLI flag (`-f`/`--file`) to override the Docker YAML file location for container commands.
  * Automatic creation and permission verification of the config directory for secure multi-user access.

* **Improvements**
  * All Docker-related commands now check for the existence of required YAML files before running.
  * Enhanced uninstall process with user confirmation to delete the home directory and improved informational messages.
  * Centralized management of config and Docker Compose file paths for consistent behavior.
  * Added descriptive comments across CLI commands for better user understanding.
  * Improved error handling and user prompts related to Docker Compose status and config directory management.

* **Bug Fixes**
  * Fixed file path handling to ensure Docker Compose operations work consistently regardless of execution location.

* **Other**
  * Minor formatting improvements in version display and log messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->