### PR TITLE
Added shortcut commands to set `graph_driver` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-04-23
+
+### Added
+
+* Added shortcut commands to swap the backend to Neo4j or PostgreSQL
+  * These commands set the `graph_driver` configuration value to `neo4j` and `pg`
+
+### Changed
+
+* The `config` command now includes a link to the _BloodHound Configuration Supplement_ documentation 
+
 ## [0.2.0] - 2025-11-14
 
 ### Changed

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	env "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
 	"github.com/spf13/cobra"
 )
@@ -11,7 +12,10 @@ var configCmd = &cobra.Command{
 	Use:   "config",
 	Short: "Display or adjust the configuration",
 	Long: `Run this command to display the configuration. Use subcommands to
-adjust the configuration or retrieve individual values.`,
+adjust the configuration or retrieve individual values.
+
+Configuration values are documented here:
+https://bloodhound.specterops.io/manage-bloodhound/bh-config`,
 	Run: configDisplay,
 }
 
@@ -20,7 +24,13 @@ func init() {
 }
 
 func configDisplay(cmd *cobra.Command, args []string) {
-	fmt.Println("[+] Current configuration and available variables:")
+	fmt.Println("[+] Current configuration:")
 	configuration := env.GetConfigAll()
 	fmt.Println(string(configuration))
+	fmt.Println("\n[+] To adjust a configuration value, use the 'config set' subcommand. For example:")
+	fmt.Println("  config set graph_driver neo4j")
+	fmt.Println("[+] To retrieve an individual configuration value, use the 'config get' subcommand. For example:")
+	fmt.Println("  config get graph_driver")
+	fmt.Println("[+] For more information on configuration options, see the documentation:")
+	fmt.Println("  https://bloodhound.specterops.io/manage-bloodhound/bh-config")
 }

--- a/cmd/graphDriver.go
+++ b/cmd/graphDriver.go
@@ -9,6 +9,10 @@ import (
 
 func setGraphDriver(driver string) {
 	env.SetConfig("graph_driver", driver)
+	// If driver is `pg` or `postgres` or `postgresql`, change string to `PostgreSQL` for user-friendly output
+	if driver == "pg" || driver == "postgres" || driver == "postgresql" {
+		driver = "PostgreSQL"
+	}
 	fmt.Printf("[+] Graph database backend set to %s. Bring containers down and up for changes to take effect.\n", driver)
 }
 

--- a/cmd/graphDriver.go
+++ b/cmd/graphDriver.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+
+	env "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
+	"github.com/spf13/cobra"
+)
+
+func setGraphDriver(driver string) {
+	env.SetConfig("graph_driver", driver)
+	fmt.Printf("[+] Graph database backend set to %s. Bring containers down and up for changes to take effect.\n", driver)
+}
+
+var neo4jCmd = &cobra.Command{
+	Use:   "neo4j",
+	Short: "Set the database backend to Neo4j",
+	Long: `Shortcut for "config set graph_driver neo4j" to set the graph database backend to Neo4j.
+
+Bring containers down and up for changes to take effect.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		setGraphDriver("neo4j")
+	},
+}
+
+var pgCmd = &cobra.Command{
+	Use:     "pg",
+	Aliases: []string{"postgres", "postgresql"},
+	Short:   "Set the database backend to PostgreSQL",
+	Long: `Shortcut for "config set graph_driver pg" to set the graph database backend to PostgreSQL.
+
+Bring containers down and up for changes to take effect.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		setGraphDriver("pg")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(neo4jCmd)
+	rootCmd.AddCommand(pgCmd)
+}

--- a/cmd/graphDriver.go
+++ b/cmd/graphDriver.go
@@ -17,8 +17,15 @@ var neo4jCmd = &cobra.Command{
 	Short: "Set the database backend to Neo4j",
 	Long: `Shortcut for "config set graph_driver neo4j" to set the graph database backend to Neo4j.
 
-Bring containers down and up for changes to take effect.`,
+Bring containers down and up for changes to take effect.
+
+For more information on graph database backends, see the documentation:
+https://bloodhound.specterops.io/manage-bloodhound/bh-config#graph_driver`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) > 0 {
+			fmt.Printf("[-] '%s' does not accept positional arguments\n", cmd.Use)
+			return
+		}
 		setGraphDriver("neo4j")
 	},
 }
@@ -29,8 +36,15 @@ var pgCmd = &cobra.Command{
 	Short:   "Set the database backend to PostgreSQL",
 	Long: `Shortcut for "config set graph_driver pg" to set the graph database backend to PostgreSQL.
 
-Bring containers down and up for changes to take effect.`,
+Bring containers down and up for changes to take effect.
+
+For more information on graph database backends, see the documentation:
+https://bloodhound.specterops.io/manage-bloodhound/bh-config#graph_driver`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) > 0 {
+			fmt.Printf("[-] '%s' does not accept positional arguments\n", cmd.Use)
+			return
+		}
 		setGraphDriver("pg")
 	},
 }

--- a/cmd/graphDriver_test.go
+++ b/cmd/graphDriver_test.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	env "github.com/SpecterOps/BloodHound_CLI/cmd/internal"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGraphDriverShortcutCommands(t *testing.T) {
+	neo4jCmd.Run(neo4jCmd, nil)
+	neo4jSetting := env.GetConfig([]string{"graph_driver"})
+	assert.Equal(t, "neo4j", neo4jSetting[0].Val, "`neo4j` command should set graph_driver to neo4j")
+
+	pgCmd.Run(pgCmd, nil)
+	pgSetting := env.GetConfig([]string{"graph_driver"})
+	assert.Equal(t, "pg", pgSetting[0].Val, "`pg` command should set graph_driver to pg")
+}

--- a/cmd/internal/env_test.go
+++ b/cmd/internal/env_test.go
@@ -41,7 +41,7 @@ func TestBloodHoundEnvironmentVariables(t *testing.T) {
 	assert.Equal(t, len(format), 2, "`GetConfig()` with two valid variables should return a two values")
 
 	// Test ``GetConfigAll()``
-	assert.Equal(t, 13, CountConfigProperties(), "`GetConfigAll()` should return all values")
+	assert.GreaterOrEqual(t, CountConfigProperties(), 13, "`GetConfigAll()` should return at least the default values")
 
 	// Test ``SetConfig()``
 	SetConfig("log_path", "bhce.log")


### PR DESCRIPTION
Added shortcut commands for setting `graph_driver` to make it easier for users to discover how to do this for OpenGraph. This also updates some terminal output to provide a documentation reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shortcut commands to switch the backend between Neo4j and PostgreSQL; updates configuration and advises restarting containers.

* **Documentation**
  * Enhanced config command output and long description with a link to the configuration guide and clearer usage examples.

* **Tests**
  * Added tests for the new backend-switching shortcuts and relaxed an existing config-test to accept additional keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->