### PR TITLE
chore: Bump examples to use PG18 - BED-8581

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -35,7 +35,7 @@ services:
       - debug-api
       - pg-only
       - sso
-    image: docker.io/library/postgres:16
+    image: docker.io/library/postgres:18
     environment:
       - PGUSER=${BH_POSTGRES_USER:-bloodhound}
       - POSTGRES_USER=${BH_POSTGRES_USER:-bloodhound}
@@ -44,7 +44,7 @@ services:
     ports:
       - ${BH_POSTGRES_PORT:-127.0.0.1:5432}:5432
     volumes:
-      - ${BH_POSTGRES_VOLUME:-postgres-data}:/var/lib/postgresql/data
+      - ${BH_POSTGRES_VOLUME:-postgres-data}:/var/lib/postgresql
     healthcheck:
       test:
         [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   app-db:
     labels:
       name: "bhce_postgres"
-    image: docker.io/library/postgres:16
+    image: docker.io/library/postgres:18
     environment:
       - PGUSER=${POSTGRES_USER:-bloodhound}
       - POSTGRES_USER=${POSTGRES_USER:-bloodhound}
@@ -28,7 +28,7 @@ services:
     # ports:
     #   - 127.0.0.1:${POSTGRES_PORT:-5432}:5432
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     healthcheck:
       test:
         [


### PR DESCRIPTION
The BHE hosted fleet runs entirely on PG18. We are moving to deprecate PG16 support and migrating new deployments to PG18 ahead of that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL database from version 16 to version 18 in development and production environments.
  * Modified database storage volume configuration for improved data persistence management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->